### PR TITLE
chore: ホストスタイル適用とCSS変数の整理

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,6 +1,11 @@
 import Marp from "@marp-team/marp-core";
 import { observe } from "@marp-team/marpit-svg-polyfill";
-import { App } from "@modelcontextprotocol/ext-apps";
+import {
+  App,
+  applyDocumentTheme,
+  applyHostFonts,
+  applyHostStyleVariables,
+} from "@modelcontextprotocol/ext-apps";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import "./styles.css";
 
@@ -407,6 +412,15 @@ app.ontoolresult = (result) => {
 };
 
 app.onhostcontextchanged = (ctx) => {
+  if (ctx.theme) {
+    applyDocumentTheme(ctx.theme);
+  }
+  if (ctx.styles?.variables) {
+    applyHostStyleVariables(ctx.styles.variables);
+  }
+  if (ctx.styles?.css?.fonts) {
+    applyHostFonts(ctx.styles.css.fonts);
+  }
   if (ctx.safeAreaInsets) {
     document.body.style.paddingTop = `${ctx.safeAreaInsets.top}px`;
     document.body.style.paddingRight = `${ctx.safeAreaInsets.right}px`;
@@ -422,6 +436,18 @@ app.ontoolcancelled = () => {
 // 初期化
 async function main() {
   await app.connect();
+
+  // 初期スタイルを適用
+  const hostContext = app.getHostContext();
+  if (hostContext?.theme) {
+    applyDocumentTheme(hostContext.theme);
+  }
+  if (hostContext?.styles?.variables) {
+    applyHostStyleVariables(hostContext.styles.variables);
+  }
+  if (hostContext?.styles?.css?.fonts) {
+    applyHostFonts(hostContext.styles.css.fonts);
+  }
 
   // Host capabilities をチェック
   const caps = app.getHostCapabilities();

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1,26 +1,38 @@
-/* フォールバック値（ホストから変数が提供されない場合） */
 :root {
+  /*
+   * ホストから提供される可能性がある変数（フォールバック値）
+   * applyHostStyleVariables() で上書きされる場合がある
+   */
   --color-background-primary: #ffffff;
-  --color-background-secondary: #f5f5f5;
   --color-background-tertiary: #e8e8e8;
   --color-text-primary: #333333;
   --color-text-secondary: #666666;
-  --color-text-danger: #e74c3c;
-  --color-text-success: #27ae60;
   --color-border-primary: #cccccc;
-  --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.15);
-  --border-radius-sm: 4px;
+
+  /* アプリ独自の変数（ホストからは提供されない） */
+  --app-shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.15);
+  --app-border-radius: 4px;
+  --app-accent: #3498db;
+  --app-accent-hover: #2980b9;
+  --app-text-on-accent: #ffffff;
+  --app-toast-background: #e74c3c;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
+    /* ホスト変数のダークモードフォールバック */
     --color-background-primary: #1a1a1a;
-    --color-background-secondary: #242424;
     --color-background-tertiary: #2d2d2d;
     --color-text-primary: #e0e0e0;
     --color-text-secondary: #999999;
     --color-border-primary: #444444;
-    --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.4);
+
+    /* アプリ独自変数のダークモード値 */
+    --app-shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.4);
+    --app-accent: #5c7599;
+    --app-accent-hover: #6b8caa;
+    --app-text-on-accent: #f5f5f5;
+    --app-toast-background: #c0392b;
   }
 }
 
@@ -40,8 +52,8 @@ body {
     Roboto,
     sans-serif
   );
-  background: var(--color-background-secondary);
   color: var(--color-text-primary);
+  overflow: hidden;
 }
 
 .toolbar {
@@ -50,7 +62,6 @@ body {
   align-items: center;
   flex-wrap: wrap;
   padding: 12px 16px 4px 16px;
-  background: var(--color-background-secondary);
 }
 
 .separator {
@@ -62,13 +73,19 @@ body {
 .toolbar select,
 .toolbar button {
   padding: 6px 12px;
-  border-radius: var(--border-radius-sm);
   border: 1px solid var(--color-border-primary);
+  border-radius: var(--app-border-radius);
   background: var(--color-background-primary);
   color: var(--color-text-primary);
   font-size: 13px;
   cursor: pointer;
   white-space: nowrap;
+}
+
+.toolbar select:focus,
+.toolbar button:focus {
+  outline: 1px solid var(--color-border-primary);
+  outline-offset: -1px;
 }
 
 @media (hover: hover) {
@@ -83,26 +100,14 @@ body {
 }
 
 .toolbar button.download-btn {
-  background: #3498db;
-  color: #ffffff;
+  background: var(--app-accent);
+  color: var(--app-text-on-accent);
   border: none;
 }
 
 @media (hover: hover) {
   .toolbar button.download-btn:hover {
-    background: #2980b9;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .toolbar button.download-btn {
-    background: #5c7599;
-  }
-
-  @media (hover: hover) {
-    .toolbar button.download-btn:hover {
-      background: #6b8caa;
-    }
+    background: var(--app-accent-hover);
   }
 }
 
@@ -121,7 +126,7 @@ body {
   display: block;
   width: 100%;
   height: auto;
-  box-shadow: var(--shadow-sm);
+  box-shadow: var(--app-shadow-sm);
 }
 
 /* トースト通知 */
@@ -129,11 +134,11 @@ body {
   position: fixed;
   top: 12px;
   right: 16px;
-  background: var(--color-text-danger);
-  color: #ffffff;
+  background: var(--app-toast-background);
+  color: var(--app-text-on-accent);
   padding: 12px 24px;
-  border-radius: var(--border-radius-sm);
-  box-shadow: var(--shadow-sm);
+  border-radius: 4px;
+  box-shadow: var(--app-shadow-sm);
   z-index: 1000;
   animation: toast-fade-in 0.3s ease;
 }


### PR DESCRIPTION
## Summary
- ext-apps SDKの`applyDocumentTheme`/`applyHostStyleVariables`/`applyHostFonts`を使用してホストからのスタイル情報を適用
- CSS変数をホスト提供可能なもの（`--color-*`）とアプリ独自のもの（`--app-*`）に明確に分離
- ダークモード対応の改善（アクセントカラー、トースト背景色など）
- 未使用変数の削除（`--color-text-danger`、`--color-text-success`、`--color-background-secondary`）
- スクロールバー非表示（`overflow: hidden`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)