### PR TITLE
fix: 初期表示時にthemeSelectとダウンロードボタンをdisabledにする

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -9,17 +9,17 @@
 <body>
   <div id="app">
     <div class="toolbar">
-      <select id="themeSelect"></select>
+      <select id="themeSelect" disabled></select>
       <span class="separator">|</span>
       <button id="firstBtn" disabled>&lt;&lt;</button>
       <button id="prevBtn" disabled>&lt;</button>
       <button id="nextBtn" disabled>&gt;</button>
       <button id="lastBtn" disabled>&gt;&gt;</button>
       <div class="download-group">
-        <button id="downloadMd" class="download-btn">MD</button>
-        <button id="downloadPdf" class="download-btn">PDF</button>
-        <button id="downloadPptx" class="download-btn">PPTX</button>
-        <button id="downloadPptxEditable" class="download-btn">Editable PPTX</button>
+        <button id="downloadMd" class="download-btn" disabled>MD</button>
+        <button id="downloadPdf" class="download-btn" disabled>PDF</button>
+        <button id="downloadPptx" class="download-btn" disabled>PPTX</button>
+        <button id="downloadPptxEditable" class="download-btn" disabled>Editable PPTX</button>
       </div>
     </div>
     <div id="previewContainer">

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -223,6 +223,10 @@ function renderSlides() {
     totalPages = slides.length;
     updatePageInfo();
     showCurrentSlide();
+
+    // themeSelectとダウンロードボタンを有効化
+    themeSelect.disabled = false;
+    updateDownloadButtonsAvailability();
   } catch (error) {
     console.error("Render failed:", error);
     showToast("レンダリングに失敗しました");
@@ -453,9 +457,6 @@ async function main() {
   const caps = app.getHostCapabilities();
   canCallServerTools = !!caps?.serverTools;
   canDownloadFile = !!caps?.downloadFile;
-
-  // ダウンロードボタンの有効/無効を設定
-  updateDownloadButtonsAvailability();
 }
 
 main();

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -89,11 +89,12 @@ body {
 }
 
 @media (hover: hover) {
-  .toolbar button:hover {
+  .toolbar button:hover:not(:disabled) {
     background: var(--color-background-tertiary);
   }
 }
 
+.toolbar select:disabled,
 .toolbar button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -106,7 +107,7 @@ body {
 }
 
 @media (hover: hover) {
-  .toolbar button.download-btn:hover {
+  .toolbar button.download-btn:hover:not(:disabled) {
     background: var(--app-accent-hover);
   }
 }


### PR DESCRIPTION
## Summary

- スライド読み込み前はthemeSelectとダウンロードボタンを操作できないようにした
- disabled状態のボタンはhoverしても色が変わらないようにした
- スライド読み込み後にcapabilityに応じて有効化

🤖 Generated with [Claude Code](https://claude.ai/claude-code)