### PR TITLE
chore: validate.shの改善とGitHub Actions関連チェック追加

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,2 @@
+ignored:
+  - DL3008  # apt-get version pinning - Debian packages are frequently updated and old versions removed

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,11 @@
 [tools]
+actionlint = "1.7.11"
+ghalint = "1.5.5"
+hadolint = "2.14.0"
 node = "24.14.1"
+pinact = "3.9.0"
 python = "3.14.3"
 ruff = "0.15.8"
 ty = "0.0.24"
 uv = "0.11.2"
+zizmor = "1.23.0"

--- a/validate.sh
+++ b/validate.sh
@@ -7,14 +7,38 @@ mise install
 # Server (Python)
 cd server
 uv sync
-ruff check --fix
-ruff format
+if [[ -n "$CI" ]]; then
+  ruff check
+  ruff format --check
+else
+  ruff check --fix
+  ruff format
+fi
 ty check
 cd ..
 
 # Client (TypeScript)
 cd client
 npm ci
-npm run lint -- --fix
-npm run format
+if [[ -n "$CI" ]]; then
+  npm run lint
+else
+  npm run lint -- --fix
+  npm run format
+fi
 npm run typecheck
+cd ..
+
+# Dockerfile
+hadolint Dockerfile
+
+# GitHub Actions
+actionlint
+ghalint run
+if [[ -n "$CI" ]]; then
+  zizmor .github/workflows/
+  pinact run --check
+else
+  zizmor --fix .github/workflows/
+  pinact run
+fi


### PR DESCRIPTION
## Summary

- actionlint, ghalint, hadolint, pinact, zizmorをmiseで管理
- validate.shでCI/ローカル分岐（CIはcheck、ローカルはfix）
- hadolint設定追加（DL3008を無視）

🤖 Generated with [Claude Code](https://claude.com/claude-code)