### PR TITLE
chore: mise-toolsグループのuv除外に正規表現を使用

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -112,7 +112,7 @@
         "mise"
       ],
       "matchPackageNames": [
-        "!uv"
+        "/^(?!uv$)/"
       ],
       "groupName": "mise-tools"
     },


### PR DESCRIPTION
## Summary

- `!uv` の否定パターンだけでは動作しないため、`/^(?!uv$)/` の正規表現でuvを除外する

🤖 Generated with [Claude Code](https://claude.com/claude-code)