### PR TITLE
chore(renovate): use astral-sh/uv for mise packageName matching

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -125,7 +125,7 @@
       ],
       "matchPackageNames": [
         "ghcr.io/astral-sh/uv",
-        "uv"
+        "astral-sh/uv"
       ],
       "groupName": "uv"
     },


### PR DESCRIPTION
## Summary

- miseのuvはpackageNameが `astral-sh/uv` なので、uvグループのmatchPackageNamesを修正
- これによりDockerfileとmiseのuvが正しく同一PRでグループ化される

🤖 Generated with [Claude Code](https://claude.com/claude-code)