### PR TITLE
chore(renovate): temporarily disable digest pinning for uv

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -127,7 +127,8 @@
         "ghcr.io/astral-sh/uv",
         "astral-sh/uv"
       ],
-      "groupName": "uv"
+      "groupName": "uv",
+      "pinDigests": false
     },
     {
       "description": "Automerge minor, patch, and digest updates",


### PR DESCRIPTION
## Summary

- uvのバージョン更新とdigestピン留めが同じブランチで競合（collision）するため、一時的にdigestピン留めを無効化
- バージョン更新PRがマージされた後、再度有効化する予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)