### PR TITLE
chore(deps): Dockerfileのuvを0.11.2に更新し、digestピン留めを再有効化

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -127,8 +127,7 @@
         "ghcr.io/astral-sh/uv",
         "astral-sh/uv"
       ],
-      "groupName": "uv",
-      "pinDigests": false
+      "groupName": "uv"
     },
     {
       "description": "Automerge minor, patch, and digest updates",

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM public.ecr.aws/docker/library/python:3.14.3-slim-trixie AS python-builder
 WORKDIR /app
 
 # uvをコピー
-COPY --from=ghcr.io/astral-sh/uv:0.10.12 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.2 /uv /usr/local/bin/uv
 
 # Python依存関係をインストール
 COPY server/pyproject.toml server/uv.lock ./


### PR DESCRIPTION
## Summary

- Dockerfile: uv 0.10.12 → 0.11.2
- renovate.json: `pinDigests: false` を削除してdigestピン留めを再有効化

🤖 Generated with [Claude Code](https://claude.com/claude-code)