### PR TITLE
chore: Biome更新時にスキーマを自動マイグレーション

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -40,6 +40,20 @@
   ],
   "packageRules": [
     {
+      "description": "Run biome migrate after biome update",
+      "matchPackageNames": [
+        "@biomejs/biome"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "cd client && npx biome migrate --write"
+        ],
+        "fileFilters": [
+          "client/biome.json"
+        ]
+      }
+    },
+    {
       "description": "Group mise tools updates",
       "matchManagers": [
         "mise"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -51,3 +51,4 @@ jobs:
         env:
           LOG_LEVEL: ${{ inputs.log-level || 'info' }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^cd client && npx biome migrate --write$"]'

--- a/client/biome.json
+++ b/client/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",

--- a/validate.sh
+++ b/validate.sh
@@ -20,7 +20,9 @@ cd ..
 # Client (TypeScript)
 cd client
 npm ci
+npx biome migrate --write
 if [[ -n "$CI" ]]; then
+  git diff --exit-code biome.json
   npm run lint
 else
   npm run lint -- --fix


### PR DESCRIPTION
## 概要

- `validate.sh` に `biome migrate --write` を追加
  - ローカル: スキーマを自動修正
  - CI: `git diff --exit-code` でマイグレーション忘れをエラー検出
- Renovateの `postUpgradeTasks` で `@biomejs/biome` 更新時にスキーマも同じPRで更新
- 既存の `biome.json` スキーマを 2.4.9 → 2.4.10 に更新

🤖 Generated with [Claude Code](https://claude.ai/claude-code)