### PR TITLE
chore: RenovateのTakumi GuardにOIDC認証を追加

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: production
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -31,9 +34,13 @@ jobs:
 
       - name: Setup Takumi Guard for PyPI
         uses: flatt-security/setup-takumi-guard-pypi@7d825811bb293b9e0230477165442580a0074280 # v1.0.0
+        with:
+          bot-id: BT01KN64BM5NBFHJNSSDYQWKE279
 
       - name: Setup Takumi Guard for npm
         uses: flatt-security/setup-takumi-guard-npm@8f53b50568e4466f2d92504f349c05b9ffcb8b59 # v1
+        with:
+          bot-id: BT01KN64BM5NBFHJNSSDYQWKE279
 
       - name: Generate GitHub App token
         id: app-token


### PR DESCRIPTION
## Summary

- RenovateワークフローのTakumi Guard（PyPI + npm）にOIDC認証（bot-id）を追加
- レート制限を5倍に緩和

🤖 Generated with [Claude Code](https://claude.com/claude-code)