### PR TITLE
chore: Node.jsとDockerイメージ、@types/nodeをLTSに制限

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
+  "extends": ["config:best-practices", "workarounds:typesNodeVersioning", "workarounds:nodeDockerVersioning"],
   "labels": ["dependencies"],
   "rebaseWhen": "conflicted",
   "prHourlyLimit": 0,
@@ -34,6 +34,12 @@
         "commands": ["pnpm exec biome migrate --write"],
         "fileFilters": ["biome.json"]
       }
+    },
+    {
+      "description": "Restrict Node.js to LTS versions",
+      "matchManagers": ["mise"],
+      "matchPackageNames": ["node"],
+      "versioning": "node"
     },
     {
       "description": "Group mise tools updates",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@marp-team/marpit-svg-polyfill": "2.1.0",
     "@types/cors": "2.8.19",
     "@types/express": "5.0.6",
-    "@types/node": "25.5.0",
+    "@types/node": "24.12.2",
     "concurrently": "9.2.1",
     "cross-env": "10.1.0",
     "typescript": "6.0.2",
@@ -55,6 +55,8 @@
     "marp-agent-mcp": "dist/index.js"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["esbuild"]
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: 5.0.6
         version: 5.0.6
       '@types/node':
-        specifier: 25.5.0
-        version: 25.5.0
+        specifier: 24.12.2
+        version: 24.12.2
       concurrently:
         specifier: 9.2.1
         version: 9.2.1
@@ -56,10 +56,10 @@ importers:
         version: 6.0.2
       vite:
         specifier: 8.0.3
-        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.5)(tsx@4.21.0)
+        version: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.5)(tsx@4.21.0)
       vite-plugin-singlefile:
         specifier: 2.3.2
-        version: 2.3.2(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.5)(tsx@4.21.0))
+        version: 2.3.2(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.5)(tsx@4.21.0))
 
 packages:
 
@@ -621,6 +621,9 @@ packages:
 
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==, tarball: https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz}
+
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==, tarball: https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz}
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==, tarball: https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz}
@@ -1317,6 +1320,9 @@ packages:
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==, tarball: https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz}
 
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz}
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==, tarball: https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz}
 
@@ -1794,6 +1800,10 @@ snapshots:
       '@types/serve-static': 2.2.0
 
   '@types/http-errors@2.0.5': {}
+
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
 
   '@types/node@25.5.0':
     dependencies:
@@ -2521,6 +2531,8 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
+  undici-types@7.16.0: {}
+
   undici-types@7.18.2: {}
 
   unpipe@1.0.0: {}
@@ -2529,13 +2541,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-plugin-singlefile@2.3.2(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.5)(tsx@4.21.0)):
+  vite-plugin-singlefile@2.3.2(rollup@4.60.1)(vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.5)(tsx@4.21.0)):
     dependencies:
       micromatch: 4.0.8
       rollup: 4.60.1
-      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.5)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.5)(tsx@4.21.0)
 
-  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.5)(tsx@4.21.0):
+  vite@8.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.5)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -2543,7 +2555,7 @@ snapshots:
       rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.5.0
+      '@types/node': 24.12.2
       esbuild: 0.27.5
       fsevents: 2.3.3
       tsx: 4.21.0


### PR DESCRIPTION
## 概要

- Renovateの設定を更新し、Node.js関連の依存関係をLTSバージョンのみに制限
- `@types/node`を25.5.0から24.12.2にダウングレード

## 変更内容

- `workarounds:typesNodeVersioning`: `@types/node`をLTSに制限
- `workarounds:nodeDockerVersioning`: DockerイメージのNode.jsをLTSに制限
- miseのNode.js用packageRule追加: miseで管理するNode.jsをLTSに制限

## テスト

- `./validate.sh` 通過確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)