### PR TITLE
chore: marpit-svg-polyfillをjsDelivr CDNから読み込むように変更

### DIFF
--- a/mcp-app.html
+++ b/mcp-app.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="color-scheme" content="light dark">
   <title>Marp Slide Preview</title>
+  <script src="https://cdn.jsdelivr.net/npm/@marp-team/marpit-svg-polyfill@2.1.0/lib/polyfill.browser.js"
+          integrity="sha384-DZPhTcCjnUmqFGL0GXmgANvsgTY5MrUreRiI49zUtCTWof1zJh0Dyz9TMqBJWMbu"
+          crossorigin="anonymous"></script>
 </head>
 <body>
   <main class="main">

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "@biomejs/biome": "2.4.10",
     "@marp-team/marp-core": "4.3.0",
-    "@marp-team/marpit-svg-polyfill": "2.1.0",
     "@types/cors": "2.8.19",
     "@types/express": "5.0.6",
     "@types/node": "24.12.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ importers:
       '@marp-team/marp-core':
         specifier: 4.3.0
         version: 4.3.0
-      '@marp-team/marpit-svg-polyfill':
-        specifier: 2.1.0
-        version: 2.1.0(@marp-team/marpit@3.2.1)
       '@types/cors':
         specifier: 2.8.19
         version: 2.8.19

--- a/server.ts
+++ b/server.ts
@@ -334,6 +334,7 @@ export function createServer(): McpServer {
       "https://fonts.googleapis.com",
       "https://fonts.gstatic.com",
       "https://esm.sh",
+      "https://cdn.jsdelivr.net",
     ],
     connectDomains: ["https://esm.sh"],
   };

--- a/src/mcp-app.ts
+++ b/src/mcp-app.ts
@@ -2,7 +2,6 @@
  * @file MCP App for Marp slide preview with theme switching and export functionality.
  */
 import Marp from "@marp-team/marp-core";
-import { observe } from "@marp-team/marpit-svg-polyfill";
 import {
   App,
   applyDocumentTheme,
@@ -97,9 +96,6 @@ const downloadFormat = document.getElementById(
   "downloadFormat",
 ) as HTMLSelectElement;
 const downloadBtn = document.getElementById("downloadBtn") as HTMLButtonElement;
-const previewContainer = document.getElementById(
-  "previewContainer",
-) as HTMLElement;
 const slideStyle = document.getElementById("slideStyle") as HTMLStyleElement;
 const slideContainer = document.querySelector(
   "#previewContainer .marpit",
@@ -235,9 +231,6 @@ function showCurrentSlide() {
       }
     });
   }
-
-  // Apply polyfill for Safari/iOS WebKit
-  observe(previewContainer);
 }
 
 // Render slides from markdown

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,12 +17,10 @@ export default defineConfig({
 
     rollupOptions: {
       input: INPUT,
-      external: ["@marp-team/marp-core", "@marp-team/marpit-svg-polyfill"],
+      external: ["@marp-team/marp-core"],
       output: {
         paths: {
           "@marp-team/marp-core": "https://esm.sh/@marp-team/marp-core@4.3.0",
-          "@marp-team/marpit-svg-polyfill":
-            "https://esm.sh/@marp-team/marpit-svg-polyfill@2.1.0",
         },
       },
     },


### PR DESCRIPTION
## Summary

- `@marp-team/marpit-svg-polyfill`をnpm依存から削除し、jsDelivr CDNから`<script>`タグで直接読み込む方式に変更
- SRI（Subresource Integrity）ハッシュを付与しサプライチェーン攻撃対策を強化
- CSPの`resourceDomains`に`cdn.jsdelivr.net`を追加

## Background

Renovateで「abandoned dependency」として警告が出ていたため、npm依存を削除してCDN読み込みに切り替え。polyfillは自動実行型（IIFE）なので、`<script>`タグで読み込むだけで動作する。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)