### PR TITLE
feat: ダウンロード時のファイル名をスライド名で指定可能に

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -65,6 +65,14 @@ export {
 // Theme schema
 const ThemeSchema = z.enum(THEMES);
 
+// Name schema (for download filename)
+const NameSchema = z
+  .string()
+  .regex(
+    /^[a-z0-9-]+$/,
+    "Only lowercase letters, numbers, and hyphens are allowed",
+  );
+
 // Resource URI for the MCP App UI
 const resourceUri = "ui://marp-agent/preview.html";
 
@@ -379,18 +387,34 @@ Theme changes are reflected immediately on the client side.`,
         theme: ThemeSchema.optional().describe(
           "Theme name (speee, border, gradient). Defaults to speee",
         ),
+        name: NameSchema.optional().describe(
+          "Slide name for filename (a-z, 0-9, hyphens only). Defaults to slide",
+        ),
       },
-      outputSchema: z.object({ markdown: z.string(), theme: z.string() }),
+      outputSchema: z.object({
+        markdown: z.string(),
+        theme: z.string(),
+        name: z.string(),
+      }),
       _meta: { ui: { resourceUri } },
     },
-    async ({ markdown, theme }) => {
+    async ({ markdown, theme, name }) => {
       const resolvedTheme = theme ?? DEFAULT_THEME;
+      const resolvedName = name ?? "slide";
       return {
-        structuredContent: { markdown, theme: resolvedTheme },
+        structuredContent: {
+          markdown,
+          theme: resolvedTheme,
+          name: resolvedName,
+        },
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify({ markdown, theme: resolvedTheme }),
+            text: JSON.stringify({
+              markdown,
+              theme: resolvedTheme,
+              name: resolvedName,
+            }),
           },
         ],
       };
@@ -477,6 +501,9 @@ are within limits. Always validate with this tool after creating or editing slid
         theme: ThemeSchema.optional().describe(
           "Theme name (speee, border, gradient). Defaults to speee",
         ),
+        name: NameSchema.optional().describe(
+          "Slide name for filename (a-z, 0-9, hyphens only). Defaults to slide",
+        ),
       },
       outputSchema: z.object({
         data_base64: z.string(),
@@ -484,13 +511,14 @@ are within limits. Always validate with this tool after creating or editing slid
         mime_type: z.string(),
       }),
     },
-    async ({ markdown, theme }) => {
+    async ({ markdown, theme, name }) => {
       const resolvedTheme = theme ?? DEFAULT_THEME;
+      const resolvedName = name ?? "slide";
       try {
         const pdfBytes = await generatePdf(markdown, resolvedTheme);
         const result = {
           data_base64: pdfBytes.toString("base64"),
-          filename: "slide.pdf",
+          filename: `${resolvedName}.pdf`,
           mime_type: "application/pdf",
         };
         return {
@@ -514,6 +542,9 @@ are within limits. Always validate with this tool after creating or editing slid
         theme: ThemeSchema.optional().describe(
           "Theme name (speee, border, gradient). Defaults to speee",
         ),
+        name: NameSchema.optional().describe(
+          "Slide name for filename (a-z, 0-9, hyphens only). Defaults to slide",
+        ),
         editable: z
           .boolean()
           .optional()
@@ -527,15 +558,16 @@ are within limits. Always validate with this tool after creating or editing slid
         mime_type: z.string(),
       }),
     },
-    async ({ markdown, theme, editable }) => {
+    async ({ markdown, theme, name, editable }) => {
       const resolvedTheme = theme ?? DEFAULT_THEME;
+      const resolvedName = name ?? "slide";
       try {
         const pptxBytes = editable
           ? await generateEditablePptx(markdown, resolvedTheme)
           : await generatePptx(markdown, resolvedTheme);
         const result = {
           data_base64: pptxBytes.toString("base64"),
-          filename: "slide.pptx",
+          filename: `${resolvedName}.pptx`,
           mime_type:
             "application/vnd.openxmlformats-officedocument.presentationml.presentation",
         };

--- a/skills/marp-agent-mcp/SKILL.md
+++ b/skills/marp-agent-mcp/SKILL.md
@@ -156,8 +156,17 @@ validate_slide({ markdown: "生成したマークダウン" })
 検証OKなら `preview_slide` でプレビューUIを表示する。
 
 ```
-preview_slide({ markdown: "生成したマークダウン", theme: "speee" })
+preview_slide({ markdown: "生成したマークダウン", theme: "speee", name: "ai-history" })
 ```
+
+#### スライド名（name）
+
+`name` パラメータには、スライドを識別する短い名前を指定する。
+
+- 英小文字・数字・ハイフンのみ使用
+- 例：`ai-history`, `project-proposal`, `quarterly-report`
+- 省略時は `slide`
+- ダウンロード時のファイル名として使用される（`{name}.pdf` 等）
 
 ### 6. プレビュー後
 

--- a/src/mcp-app.ts
+++ b/src/mcp-app.ts
@@ -28,6 +28,7 @@ import speeeTheme from "../themes/speee.css?raw";
 interface PreviewResultData {
   markdown: string;
   theme: ThemeId;
+  name: string;
 }
 
 // Structured content from export_pdf / export_pptx tools
@@ -56,6 +57,7 @@ const app = new App({ name: "Marp Preview", version: VERSION });
 // App state
 let currentMarkdown: string | null = null;
 let currentTheme: ThemeId = DEFAULT_THEME;
+let currentName = "slide";
 let currentPage = 0;
 let totalPages = 1;
 let slides: string[] = [];
@@ -314,7 +316,7 @@ async function handleMarkdownDownload() {
         {
           type: "resource",
           resource: {
-            uri: "file:///slide.md",
+            uri: `file:///${currentName}.md`,
             mimeType: "text/markdown",
             blob: base64Data,
           },
@@ -341,7 +343,12 @@ async function handleServerExport(
     const result = await app.callServerTool(
       {
         name: toolName,
-        arguments: { markdown: currentMarkdown, theme: currentTheme, ...args },
+        arguments: {
+          markdown: currentMarkdown,
+          theme: currentTheme,
+          name: currentName,
+          ...args,
+        },
       },
       { timeout: SERVER_TOOL_TIMEOUT_MS },
     );
@@ -423,6 +430,9 @@ app.ontoolresult = (result) => {
     if (data.theme) {
       currentTheme = data.theme as ThemeId;
       themeSelect.value = currentTheme;
+    }
+    if (data.name) {
+      currentName = data.name;
     }
     renderSlides();
 


### PR DESCRIPTION
## Summary

- `preview_slide` に `name` パラメータを追加
- ダウンロード時のファイル名として `{name}.pdf` / `{name}.pptx` / `{name}.md` を使用
- 英小文字・数字・ハイフンのみ許可（zodでバリデーション）
- 省略時は `slide` がデフォルト
- スキル（SKILL.md）にスライド名の説明を追加

🤖 Generated with [Claude Code](https://claude.ai/code)