### PR TITLE
chore: validate.shの簡素化とpnpmスクリプト名変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "start": "cross-env NODE_ENV=development pnpm run build && pnpm run serve",
     "start:stdio": "cross-env NODE_ENV=development pnpm run build 1>&2 && pnpm run serve:stdio",
     "dev": "cross-env NODE_ENV=development concurrently \"pnpm run watch\" \"pnpm run serve\"",
-    "lint": "biome check",
-    "format": "biome check --write",
+    "check": "biome check",
+    "check:write": "biome check --write",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.server.json --noEmit",
     "test": "bun test"
   },

--- a/validate.sh
+++ b/validate.sh
@@ -23,4 +23,4 @@ actionlint
 ghalint run
 
 # Check for uncommitted changes
-git diff --exit-code
+git diff --exit-code -- . ':!.npmrc'

--- a/validate.sh
+++ b/validate.sh
@@ -1,19 +1,15 @@
 #!/bin/bash
 set -e
 
+# mise
 eval "$(mise activate bash)"
 mise install
 
-# TypeScript (Biome lint/format + tsc type check + tests)
+# TypeScript
 pnpm install --frozen-lockfile
+pnpm audit --fix --ignore-unfixable
 pnpm exec biome migrate --write
-if [[ -n "$CI" ]]; then
-  git diff --exit-code biome.json
-  pnpm run lint
-else
-  pnpm run lint --fix
-  pnpm run format
-fi
+pnpm run check:write
 pnpm run typecheck
 pnpm run test
 
@@ -21,12 +17,10 @@ pnpm run test
 hadolint Dockerfile
 
 # GitHub Actions
+pinact run
+zizmor --fix .github/workflows/
 actionlint
 ghalint run
-if [[ -n "$CI" ]]; then
-  zizmor .github/workflows/
-  pinact run --check
-else
-  zizmor --fix .github/workflows/
-  pinact run
-fi
+
+# Check for uncommitted changes
+git diff --exit-code


### PR DESCRIPTION
## 概要

validate.shスクリプトの簡素化とpackage.jsonのスクリプト名を変更しました。

## 変更内容

### validate.sh
- CI/ローカルの分岐ロジックを削除し、すべて統一
- ファイル書き換え処理を先に実行し、その後チェックを実行する順序に変更
- `pnpm audit --fix --ignore-unfixable` をセキュリティチェックとして追加
- 最後に `git diff --exit-code` で変更検出

### package.json
- `lint` → `check` に変更
- `format` → `check:write` に変更
- Biomeの標準的な命名規則に合わせた

🤖 Generated with [Claude Code](https://claude.com/claude-code)