### PR TITLE
chore: vulnerabilityAlertsを有効化、lockFileMaintenanceを無効化

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,14 @@
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "minimumReleaseAge": "3 days",
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "minimumReleaseAge": null,
+    "automerge": true
+  },
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -68,13 +76,13 @@
       "groupName": "github-actions"
     },
     {
-      "description": "Disable minimumReleaseAge for digest and lockFileMaintenance",
-      "matchUpdateTypes": ["digest", "lockFileMaintenance"],
+      "description": "Disable minimumReleaseAge for digest updates",
+      "matchUpdateTypes": ["digest"],
       "minimumReleaseAge": null
     },
     {
-      "description": "Automerge minor, patch, digest, and lockFileMaintenance updates",
-      "matchUpdateTypes": ["minor", "patch", "digest", "lockFileMaintenance"],
+      "description": "Automerge minor, patch, and digest updates",
+      "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
## 概要

- セキュリティ修正を即座に適用するため `vulnerabilityAlerts` を有効化
- 未検証の推移的依存更新を避けるため `lockFileMaintenance` を無効化

🤖 Generated with [Claude Code](https://claude.com/claude-code)