### PR TITLE
chore: Renovate設定エラーを修正

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -42,7 +42,8 @@
     },
     {
       "description": "Add release date to PR title if available",
-      "prTitle": "Update {{{depName}}} to {{{newVersion}}}{{#if releaseTimestamp}} ({{{replace 'T.*' '' releaseTimestamp}}}){{/if}}"
+      "matchPackageNames": ["*"],
+      "commitMessageExtra": "{{#if releaseTimestamp}}({{{replace 'T.*' '' releaseTimestamp}}}){{/if}}"
     },
     {
       "description": "Restrict Node.js to LTS versions",


### PR DESCRIPTION
## Summary

- `matchPackageNames`セレクターを追加（packageRulesにはmatch*/exclude*セレクターが必須）
- `prTitle`（非推奨）を`commitMessageExtra`に変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)