### PR TITLE
chore: automergeとminimumReleaseAgeのルールにpinDigestを追加

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -60,13 +60,13 @@
       }
     },
     {
-      "description": "Disable minimumReleaseAge for digest updates",
-      "matchUpdateTypes": ["digest"],
+      "description": "Disable minimumReleaseAge for digest and pinDigest updates",
+      "matchUpdateTypes": ["digest", "pinDigest"],
       "minimumReleaseAge": null
     },
     {
-      "description": "Automerge minor, patch, and digest updates",
-      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "description": "Automerge minor, patch, digest, and pinDigest updates",
+      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
## Summary
- `pinDigest` を minimumReleaseAge と automerge のルールに追加
- 初回のダイジェストピン留めも待機なしで自動マージされるようになる

🤖 Generated with [Claude Code](https://claude.ai/code)