### PR TITLE
chore: Renovate設定を簡素化

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,10 +6,11 @@
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "minimumReleaseAge": "3 days",
+  "automerge": true,
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "vulnerabilityAlerts": {
     "enabled": true,
-    "minimumReleaseAge": null,
-    "automerge": true
+    "minimumReleaseAge": null
   },
   "lockFileMaintenance": {
     "enabled": false
@@ -60,14 +61,9 @@
       }
     },
     {
-      "description": "Disable minimumReleaseAge for digest and pinDigest updates",
-      "matchUpdateTypes": ["digest", "pinDigest"],
-      "minimumReleaseAge": null
-    },
-    {
-      "description": "Automerge minor, patch, digest, and pinDigest updates",
-      "matchUpdateTypes": ["minor", "patch", "digest", "pinDigest"],
-      "automerge": true
+      "description": "Disable automerge for major updates",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `minimumReleaseAgeBehaviour: timestamp-optional`を追加し、`releaseTimestamp`がないパッケージの猶予期間をスキップ
- `automerge: true`をグローバルに設定し、majorのみ無効化
- 冗長になったdigest/pinDigestルールと`vulnerabilityAlerts.automerge`を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)