### PR TITLE
chore: Takumi Guardを削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Takumi Guard for npm
-        uses: flatt-security/setup-takumi-guard-npm@3c4ad0e8c9e81d0efbccff304adac60e42e3f32d # v1.1.0
-        with:
-          bot-id: BT01KN64BM5NBFHJNSSDYQWKE279
-
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -32,11 +32,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Takumi Guard for npm
-        uses: flatt-security/setup-takumi-guard-npm@3c4ad0e8c9e81d0efbccff304adac60e42e3f32d # v1.1.0
-        with:
-          bot-id: BT01KN64BM5NBFHJNSSDYQWKE279
-
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://npm.flatt.tech/

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN pnpm run build
 # ============================================
 FROM public.ecr.aws/docker/library/node:24.14.1-trixie-slim@sha256:9707cd4542f400df5078df04f9652a272429112f15202d22b5b8bdd148df494f AS marp-builder
 
-COPY .npmrc /root/.npmrc
 RUN npm install -g @marp-team/marp-cli@4.3.1
 
 # ============================================

--- a/validate.sh
+++ b/validate.sh
@@ -25,4 +25,4 @@ actionlint
 ghalint run
 
 # Check for uncommitted changes
-git diff --exit-code -- . ':!.npmrc'
+git diff --exit-code


### PR DESCRIPTION
## Summary

- セキュリティパッチも検疫対象となり適用が遅れるため、Takumi Guardを削除
- CI/Renovateワークフロー、`.npmrc`、Dockerfile、`validate.sh` から関連設定を一括除去

🤖 Generated with [Claude Code](https://claude.com/claude-code)