### PR TITLE
chore: 不要になったid-token: write権限を削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
     environment: production
     permissions:
       contents: read
-      id-token: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,7 +25,6 @@ jobs:
     environment: production
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- CI、Renovateワークフローから`id-token: write`権限を削除
- Takumi Guard削除に伴い、OIDCトークンが不要になったため

🤖 Generated with [Claude Code](https://claude.com/claude-code)