### PR TITLE
chore: miseのバージョンを2026.4.8に固定

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,20 @@
   "customManagers": [
     {
       "customType": "regex",
+      "managerFilePatterns": [
+        "/^\\.mise\\.toml$/",
+        "/^\\.github/workflows/ci\\.yml$/"
+      ],
+      "matchStrings": [
+        "min_version\\s*=\\s*\"(?<currentValue>[^\"]+)\"",
+        "jdx/mise-action@[^\\n]*\\n\\s*with:\\s*\\n\\s*version:\\s*(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "jdx/mise",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["/Dockerfile$/"],
       "matchStrings": [
         "npm install -g bun@(?<currentValue>[^\\s]+)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          version: 2026.4.8
 
       - name: Run validation script
         run: bash validate.sh

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,5 @@
+min_version = "2026.4.8"
+
 [tools]
 actionlint = "1.7.12"
 bun = "1.3.11"


### PR DESCRIPTION
## Summary
- `.mise.toml`に`min_version`を、CIの`mise-action`ステップに`version`入力を追加し、ローカルとCIで同じmiseリリースを使うようにする。
- Renovateの`customManagers`を拡張し、`jdx/mise`のGitHubリリースデータソース経由で`.mise.toml`と`ci.yml`のバージョンを同期して更新するようにする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)