### PR TITLE
refactor: パス解決を PROJECT_ROOT に集約

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -38,20 +38,14 @@ import {
 
 const execFileAsync = promisify(execFile);
 
-// Works both from source (server.ts) and compiled (dist/server.js)
-const DIST_DIR = import.meta.filename.endsWith(".ts")
-  ? path.join(import.meta.dirname, "dist")
-  : import.meta.dirname;
+// Works both from source (server.ts at project root) and compiled (dist/server.js)
+const PROJECT_ROOT = import.meta.filename.endsWith(".ts")
+  ? import.meta.dirname
+  : path.join(import.meta.dirname, "..");
 
-// Path to the skill zip file
-export const SKILL_ZIP_PATH = import.meta.filename.endsWith(".ts")
-  ? path.join(import.meta.dirname, "skill.zip")
-  : path.join(import.meta.dirname, "..", "skill.zip");
-
-// Path to the theme files directory
-const THEMES_DIR = import.meta.filename.endsWith(".ts")
-  ? path.join(import.meta.dirname, "themes")
-  : path.join(import.meta.dirname, "..", "themes");
+const DIST_DIR = path.join(PROJECT_ROOT, "dist");
+export const SKILL_ZIP_PATH = path.join(PROJECT_ROOT, "skill.zip");
+const THEMES_DIR = path.join(PROJECT_ROOT, "themes");
 
 // Re-export validation constants for tests
 export {


### PR DESCRIPTION
## Summary
- ソース実行モードとビルド実行モードで分岐していた3箇所のパス定義を `PROJECT_ROOT` に集約
- 各アセット (`DIST_DIR` / `SKILL_ZIP_PATH` / `THEMES_DIR`) を `PROJECT_ROOT` からの相対として素直に表現
- 振る舞いの変更なし、14行 → 8行

🤖 Generated with [Claude Code](https://claude.com/claude-code)