### PR TITLE
chore: Renovateでbiome.jsonの$schemaを同期更新する

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,6 +47,15 @@
       ],
       "depNameTemplate": "@marp-team/marp-cli",
       "datasourceTemplate": "npm"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^biome\\.json$/"],
+      "matchStrings": [
+        "https://biomejs\\.dev/schemas/(?<currentValue>[^/]+)/schema\\.json"
+      ],
+      "depNameTemplate": "@biomejs/biome",
+      "datasourceTemplate": "npm"
     }
   ],
   "packageRules": [
@@ -65,14 +74,6 @@
       "matchManagers": ["mise"],
       "matchPackageNames": ["node"],
       "versioning": "node"
-    },
-    {
-      "description": "Run biome migrate after biome update",
-      "matchPackageNames": ["@biomejs/biome"],
-      "postUpgradeTasks": {
-        "commands": ["pnpm exec biome migrate --write"],
-        "fileFilters": ["biome.json"]
-      }
     },
     {
       "description": "Disable automerge for major updates",

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -53,4 +53,3 @@ jobs:
         env:
           LOG_LEVEL: ${{ inputs.log-level || 'info' }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS: '["^pnpm exec biome migrate --write$"]'


### PR DESCRIPTION
## 概要

- `customManager` で `biome.json` の `$schema` URL を `@biomejs/biome` に紐付け、`package.json` と同じ PR で同時更新されるようにする
- 動作していなかった `postUpgradeTasks`（`pnpm exec biome migrate --write`）の packageRule を削除
- 不要になった `RENOVATE_ALLOWED_POST_UPGRADE_COMMANDS` 環境変数を削除

## 背景

#73 で `@biomejs/biome` を更新した際、PR に `biome.json` の `$schema` URL 更新が含まれず、CI 内の `biome migrate --write` がバージョン差分を書き換えた結果、`git diff --exit-code` で失敗していた。

ローカルで `renovate --dry-run` を実行して、`biome.json` と `package.json` の更新が同一ブランチ (`renovate/biomejs-biome-2.x`) に集約されることを確認済み。