### PR TITLE
chore: Renovate設定をconfig:best-practicesのデフォルトに寄せる

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices", "workarounds:typesNodeVersioning", "workarounds:nodeDockerVersioning"],
   "labels": ["dependencies"],
-  "rebaseWhen": "conflicted",
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
   "minimumReleaseAge": "3 days",
@@ -59,16 +58,6 @@
     }
   ],
   "packageRules": [
-    {
-      "description": "Disable all grouping",
-      "matchPackageNames": ["*"],
-      "groupName": null
-    },
-    {
-      "description": "Add release date to PR title if available",
-      "matchPackageNames": ["*"],
-      "commitMessageExtra": "{{#if releaseTimestamp}}({{{replace 'T.*' '' releaseTimestamp}}}){{/if}}"
-    },
     {
       "description": "Restrict Node.js to LTS versions",
       "matchManagers": ["mise"],


### PR DESCRIPTION
## Summary

- グループ化無効化ルールを削除し、`config:best-practices` のデフォルト（`group:monorepos` + `group:recommended`）に委ねる
- PRタイトルにリリース日を付与するルールを削除（3日の検疫期間が主眼のため不要）
- グローバルデフォルトと同値で冗長な `rebaseWhen: "conflicted"` を削除

パッケージ単位でブランチが再利用されることで発生しやすい「Automerge: Disabled because a matching PR was automerged previously.」の頻度を、最小限のグループ化で緩和する狙い。

🤖 Generated with [Claude Code](https://claude.com/claude-code)