### PR TITLE
chore: Renovateの公式カスタムマネージャープリセットに寄せる

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", "workarounds:typesNodeVersioning", "workarounds:nodeDockerVersioning"],
+  "extends": [
+    "config:best-practices",
+    "customManagers:biomeVersions",
+    "customManagers:dockerfileVersions",
+    "workarounds:nodeDockerVersioning",
+    "workarounds:typesNodeVersioning"
+  ],
   "labels": ["dependencies"],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
@@ -28,33 +34,6 @@
       "depNameTemplate": "jdx/mise",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v?(?<version>.+)$"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/Dockerfile$/"],
-      "matchStrings": [
-        "npm install -g bun@(?<currentValue>[^\\s]+)"
-      ],
-      "depNameTemplate": "bun",
-      "datasourceTemplate": "npm"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/Dockerfile$/"],
-      "matchStrings": [
-        "npm install -g @marp-team/marp-cli@(?<currentValue>[^\\s]+)"
-      ],
-      "depNameTemplate": "@marp-team/marp-cli",
-      "datasourceTemplate": "npm"
-    },
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^biome\\.json$/"],
-      "matchStrings": [
-        "https://biomejs\\.dev/schemas/(?<currentValue>[^/]+)/schema\\.json"
-      ],
-      "depNameTemplate": "@biomejs/biome",
-      "datasourceTemplate": "npm"
     }
   ],
   "packageRules": [

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ FROM public.ecr.aws/docker/library/node:24.14.1-trixie-slim@sha256:9707cd4542f40
 WORKDIR /app
 
 # Install pnpm and bun
-RUN corepack enable && corepack use pnpm && npm install -g bun@1.3.12
+# renovate: datasource=npm depName=bun
+ARG BUN_VERSION=1.3.12
+RUN corepack enable && corepack use pnpm && npm install -g bun@${BUN_VERSION}
 
 # Install dependencies
 COPY package.json pnpm-lock.yaml ./
@@ -29,7 +31,9 @@ RUN pnpm run build
 # ============================================
 FROM public.ecr.aws/docker/library/node:24.14.1-trixie-slim@sha256:9707cd4542f400df5078df04f9652a272429112f15202d22b5b8bdd148df494f AS marp-builder
 
-RUN npm install -g @marp-team/marp-cli@4.3.1
+# renovate: datasource=npm depName=@marp-team/marp-cli
+ARG MARP_CLI_VERSION=4.3.1
+RUN npm install -g @marp-team/marp-cli@${MARP_CLI_VERSION}
 
 # ============================================
 # Stage 3: Final image


### PR DESCRIPTION
## Summary

- biome.json の schema URL を `customManagers:biomeVersions` プリセットで管理
- Dockerfile の bun / marp-cli バージョンを `customManagers:dockerfileVersions` プリセットで管理（`ARG` + `# renovate:` コメント形式に変更）
- 自前の正規表現カスタムマネージャー3ブロックを削除
- `extends` をアルファベット順に整理

ローカルで `renovate --dry-run` を実行し、3依存とも新プリセット経由で正しく検出されることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)