### PR TITLE
chore: Renovate設定に追加の公式プリセットを採用

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,33 +4,26 @@
     "config:best-practices",
     "customManagers:biomeVersions",
     "customManagers:dockerfileVersions",
+    "customManagers:githubActionsVersions",
     "workarounds:nodeDockerVersioning",
-    "workarounds:typesNodeVersioning"
+    "workarounds:typesNodeVersioning",
+    ":automergeAll",
+    ":label(dependencies)",
+    ":maintainLockFilesDisabled",
+    ":prConcurrentLimitNone",
+    ":prHourlyLimitNone"
   ],
-  "labels": ["dependencies"],
-  "prHourlyLimit": 0,
-  "prConcurrentLimit": 0,
   "minimumReleaseAge": "3 days",
-  "automerge": true,
   "minimumReleaseAgeBehaviour": "timestamp-optional",
   "vulnerabilityAlerts": {
     "enabled": true,
     "minimumReleaseAge": null
   },
-  "lockFileMaintenance": {
-    "enabled": false
-  },
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "/^\\.mise\\.toml$/",
-        "/^\\.github/workflows/ci\\.yml$/"
-      ],
-      "matchStrings": [
-        "min_version\\s*=\\s*\"(?<currentValue>[^\"]+)\"",
-        "jdx/mise-action@[^\\n]*\\n\\s*with:\\s*\\n\\s*version:\\s*(?<currentValue>\\S+)"
-      ],
+      "managerFilePatterns": ["/^\\.mise\\.toml$/"],
+      "matchStrings": ["min_version\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "jdx/mise",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v?(?<version>.+)$"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
     environment: production
     permissions:
       contents: read
+    env:
+      # renovate: datasource=github-releases depName=jdx/mise extractVersion=^v?(?<version>.+)$
+      MISE_VERSION: 2026.4.9
 
     steps:
       - name: Checkout code
@@ -27,7 +30,7 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
-          version: 2026.4.9
+          version: ${{ env.MISE_VERSION }}
 
       - name: Run validation script
         run: bash validate.sh


### PR DESCRIPTION
## Summary

- `customManagers:githubActionsVersions` を採用し、ci.yml の mise バージョンを `env.MISE_VERSION` 経由で管理
- `:automergeAll` / `:label(dependencies)` / `:maintainLockFilesDisabled` / `:prConcurrentLimitNone` / `:prHourlyLimitNone` で直接指定をプリセットに置換
- 自前のカスタムマネージャーは `.mise.toml` の `min_version` 用のみ残存

ローカルで `renovate --dry-run` を実行し、ci.yml / .mise.toml 両方から `jdx/mise` が検出されることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)