### PR TITLE
chore: ブランチ制限した production environment でも CI が通るようにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     name: Run Linting, Type Check, and Tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: production
     permissions:
       contents: read
     env:

--- a/validate.sh
+++ b/validate.sh
@@ -9,7 +9,9 @@ mise install
 # TypeScript
 pnpm install --frozen-lockfile
 pnpm licenses ls
-pnpm audit --fix --ignore-unfixable
+# TODO: re-enable once pnpm audit supports npm's bulk advisory endpoint
+# https://github.com/pnpm/pnpm/issues/11265
+# pnpm audit --fix --ignore-unfixable
 pnpm exec biome migrate --write
 pnpm run check:write
 pnpm run typecheck


### PR DESCRIPTION
## Summary
- CI ジョブから未使用の `environment: production` を削除しました。Environment のデプロイ対象を `main` のみに制限したときに、PR の CI がブロックされるのを防ぎます。
- pnpm/pnpm#11265 が解決するまで `pnpm audit` を一時的にコメントアウトしました。npm がレガシーの audit エンドポイントを廃止したため、pnpm 10.x / 11.0.0-rc.0 では audit が 410 で失敗するためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)