### PR TITLE
chore: dependencies を固定バージョンに変更し hono overrides を削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "test": "bun test"
   },
   "dependencies": {
-    "@modelcontextprotocol/ext-apps": "^1.3.2",
-    "@modelcontextprotocol/sdk": "^1.29.0",
-    "cors": "^2.8.5",
-    "express": "^5.1.0",
-    "get-east-asian-width": "^1.3.0",
-    "zod": "^4.3.6"
+    "@modelcontextprotocol/ext-apps": "1.5.0",
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "cors": "2.8.6",
+    "express": "5.2.1",
+    "get-east-asian-width": "1.5.0",
+    "zod": "4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.11",
@@ -56,11 +56,6 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"
-    ],
-    "overrides": {
-      "hono@<4.12.12": ">=4.12.12",
-      "hono@>=4.0.0 <=4.12.11": ">=4.12.12",
-      "@hono/node-server@<1.19.13": ">=1.19.13"
-    }
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,32 +4,27 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  hono@<4.12.12: '>=4.12.12'
-  hono@>=4.0.0 <=4.12.11: '>=4.12.12'
-  '@hono/node-server@<1.19.13': '>=1.19.13'
-
 importers:
 
   .:
     dependencies:
       '@modelcontextprotocol/ext-apps':
-        specifier: ^1.3.2
+        specifier: 1.5.0
         version: 1.5.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
+        specifier: 1.29.0
         version: 1.29.0(zod@4.3.6)
       cors:
-        specifier: ^2.8.5
+        specifier: 2.8.6
         version: 2.8.6
       express:
-        specifier: ^5.1.0
+        specifier: 5.2.1
         version: 5.2.1
       get-east-asian-width:
-        specifier: ^1.3.0
+        specifier: 1.5.0
         version: 1.5.0
       zod:
-        specifier: ^4.3.6
+        specifier: 4.3.6
         version: 4.3.6
     devDependencies:
       '@biomejs/biome':
@@ -156,7 +151,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.12'
+      hono: ^4
 
   '@marp-team/marp-core@4.3.0':
     resolution: {integrity: sha512-Qwd0wsHS+7bdCBmmnxCU2OKclCSdsVu4U474zSs44Y2SMXr6d9wBYAMD5IXI4dbmaB57Ez5fdPUxPZZsFo8Tmw==}


### PR DESCRIPTION
## Summary
- \`dependencies\` を \`devDependencies\` と同じく固定バージョン指定に変更（インストール済みバージョンに合わせて pin）
- \`pnpm.overrides\` の hono / @hono/node-server を削除。通常解決でも脆弱性修正版（hono >= 4.12.12, @hono/node-server >= 1.19.13）が選ばれるため不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)