### PR TITLE
chore: pnpm audit を --ignore-registry-errors 付きで再有効化

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -9,9 +9,7 @@ mise install
 # TypeScript
 pnpm install --frozen-lockfile
 pnpm licenses ls
-# TODO: re-enable once pnpm audit supports npm's bulk advisory endpoint
-# https://github.com/pnpm/pnpm/issues/11265
-# pnpm audit --fix --ignore-unfixable
+pnpm audit --fix --ignore-unfixable --ignore-registry-errors
 pnpm exec biome migrate --write
 pnpm run check:write
 pnpm run typecheck


### PR DESCRIPTION
## Summary

- `pnpm audit` を無効化していた TODO コメントを削除し、`--ignore-registry-errors` を追加して再有効化
- npm の bulk advisory endpoint 未対応（[pnpm/pnpm#11265](https://github.com/pnpm/pnpm/issues/11265)）によるレジストリエラーを無視することで、audit を実行可能にする

🤖 Generated with [Claude Code](https://claude.com/claude-code)