### PR TITLE
chore: min_version を hard/soft 分離

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/^\\.mise\\.toml$/"],
-      "matchStrings": ["min_version\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
+      "matchStrings": ["soft\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
       "depNameTemplate": "jdx/mise",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v?(?<version>.+)$"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,4 @@
-min_version = "2026.4.9"
+min_version = { hard = "2026.4.8", soft = "2026.4.9" }
 
 [tools]
 actionlint = "1.7.12"


### PR DESCRIPTION
## Summary
- \`.mise.toml\` の \`min_version\` をオブジェクト形式に変更し、\`hard\` と \`soft\` を分離
- \`hard = 2026.4.8\`：実際に動作要件となる floor（今後は手動で上げる）
- \`soft = 2026.4.9\`：推奨バージョン（Renovate が自動追従）
- custom regex manager を \`soft\` のみにマッチするよう変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)