### PR TITLE
chore: min_version を hard のみの指定に簡素化

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,16 +19,6 @@
     "enabled": true,
     "minimumReleaseAge": null
   },
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": ["/^\\.mise\\.toml$/"],
-      "matchStrings": ["soft\\s*=\\s*\"(?<currentValue>[^\"]+)\""],
-      "depNameTemplate": "jdx/mise",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v?(?<version>.+)$"
-    }
-  ],
   "packageRules": [
     {
       "description": "Restrict Node.js to LTS versions",

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,4 +1,4 @@
-min_version = { hard = "2026.4.8", soft = "2026.4.9" }
+min_version = "2026.4.8"
 
 [tools]
 actionlint = "1.7.12"


### PR DESCRIPTION
## Summary
- \`.mise.toml\` の \`min_version\` を単純な文字列形式（hard デフォルト）に戻す
- \`renovate.json\` から \`.mise.toml\` 向けの custom regex manager を削除
- CI 側は \`MISE_VERSION\` でリリースを追従済み（\`customManagers:githubActionsVersions\` preset 経由）のため、カバレッジの損失はなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)