### PR TITLE
chore: minimumReleaseAge を 1 day に短縮

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,7 @@
     ":prConcurrentLimitNone",
     ":prHourlyLimitNone"
   ],
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "1 day",
   "minimumReleaseAgeBehaviour": "timestamp-optional",
   "vulnerabilityAlerts": {
     "enabled": true,


### PR DESCRIPTION
## Summary

- Renovate の \`minimumReleaseAge\` を \`3 days\` → \`1 day\` に変更
- 待機中の更新が早く流れるようにする

サプライチェーン攻撃への保護は弱まるが、個人プロジェクトとして許容範囲と判断。
🤖 Generated with [Claude Code](https://claude.com/claude-code)