### PR TITLE
chore: Renovate の PR タイトルを semantic commits 化

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,8 @@
     ":label(dependencies)",
     ":maintainLockFilesDisabled",
     ":prConcurrentLimitNone",
-    ":prHourlyLimitNone"
+    ":prHourlyLimitNone",
+    ":semanticCommits"
   ],
   "minimumReleaseAge": "1 day",
   "minimumReleaseAgeBehaviour": "timestamp-optional",


### PR DESCRIPTION
## Summary

- Renovate の extends に `:semanticCommits` を追加し、PR タイトルを Conventional Commits 形式（例: `chore(deps): ...`）に揃える