### PR TITLE
chore: config:best-practices による minimumReleaseAge 上書きを防止

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,10 +9,13 @@
     "workarounds:typesNodeVersioning",
     ":automergeAll",
     ":label(dependencies)",
-    ":maintainLockFilesDisabled",
     ":prConcurrentLimitNone",
     ":prHourlyLimitNone",
     ":semanticCommits"
+  ],
+  "ignorePresets": [
+    "security:minimumReleaseAgeNpm",
+    ":maintainLockFilesWeekly"
   ],
   "minimumReleaseAge": "1 day",
   "minimumReleaseAgeBehaviour": "timestamp-optional",


### PR DESCRIPTION
## Summary

- `config:best-practices` に含まれる `security:minimumReleaseAgeNpm` が npm パッケージの `minimumReleaseAge` を `3 days` に上書きしていたため、トップレベルの `1 day` 設定が効かず、頻繁にリリースされるパッケージ（例: `npm:renovate`）で PR が作られない問題を修正
- `ignorePresets` で `security:minimumReleaseAgeNpm` と `:maintainLockFilesWeekly` を除外し、不要になった `:maintainLockFilesDisabled` を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)