### PR TITLE
fix(deps): pnpm を 11.0.0-rc.1 に上げて audit エンドポイント問題を解消

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -7,9 +7,12 @@ install_before = "1d"
 bun = "1.3.12"
 node = "24.14.1"
 "aqua:hadolint/hadolint" = "2.14.0"
-"aqua:pnpm/pnpm" = "10.33.0"
 "aqua:rhysd/actionlint" = "1.7.12"
 "aqua:suzuki-shunsuke/ghalint" = "1.5.5"
 "aqua:suzuki-shunsuke/pinact" = "3.9.0"
 "aqua:zizmorcore/zizmor" = "1.24.1"
 "npm:renovate" = "43.120.1"
+
+[tools."npm:pnpm"]
+version = "11.0.0-rc.1"
+install_before = "0d"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marp-agent-mcp",
   "version": "1.0.0",
   "private": true,
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.0.0-rc.1",
   "type": "module",
   "description": "Marp slide generation MCP server with preview UI",
   "license": "MIT",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -932,8 +932,8 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -1496,9 +1496,9 @@ snapshots:
 
   '@epic-web/invariant@1.0.0': {}
 
-  '@hono/node-server@1.19.13(hono@4.12.12)':
+  '@hono/node-server@1.19.13(hono@4.12.14)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.14
 
   '@marp-team/marp-core@4.3.0':
     dependencies:
@@ -1532,7 +1532,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.12)
+      '@hono/node-server': 1.19.13(hono@4.12.14)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -1542,7 +1542,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.12
+      hono: 4.12.14
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -2003,7 +2003,7 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  hono@4.12.12: {}
+  hono@4.12.14: {}
 
   http-errors@2.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,184 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 11.0.0-rc.1
+        version: 11.0.0-rc.1
+      pnpm:
+        specifier: 11.0.0-rc.1
+        version: 11.0.0-rc.1
+
+packages:
+
+  '@pnpm/exe@11.0.0-rc.1':
+    resolution: {integrity: sha512-nGmEQeq3w+zHDtbnsdj69EaW78UkHwIeNR9uOx893JasG3boZuiFUugwOKpQIDfMBDFK+32SDMLyqDjuaSp/ZQ==}
+    hasBin: true
+
+  '@pnpm/linux-arm64@11.0.0-rc.1':
+    resolution: {integrity: sha512-HJY94Zz6IEc55kPoMB+ocXWWUmqrHohwN3gxMFfFODWpKUYsNvheFJxpTRn6wIZj7n7pYSVxdGZjDvzedbeuoQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@pnpm/linux-x64@11.0.0-rc.1':
+    resolution: {integrity: sha512-UIGMWTZqlYaTS4EjHMX1xEgwlBfW8aKCu85kZMEcFsO08S++3F7Au09fa4t+MbjeaVcgz8LSGA1zf5nqY/uK1w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@pnpm/macos-arm64@11.0.0-rc.1':
+    resolution: {integrity: sha512-+LC41cEalZMUCrDDNyQ2a/krK7cn6WnKDlZDBkiLVqZInfW8c31yAYIEPdkesVRudr7lneFSEP/I3AkcpsBJdQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/macos-x64@11.0.0-rc.1':
+    resolution: {integrity: sha512-vMccaVqCCkldd3QywMc48R1wQMnXBzE13kCHu5hKTd8NLJgHOrnXsN9Qt7jj3T9WT4zRjfbfua7HzGX9ZYR02A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/win-arm64@11.0.0-rc.1':
+    resolution: {integrity: sha512-5GMjLMefmzgsIHYparaGwwNuFrtFXO5xpbA0MBT+kCYtNqy1ORGsoU0jjhKMmxcuBj6L/P7X21Zfhzc7CudeoA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/win-x64@11.0.0-rc.1':
+    resolution: {integrity: sha512-ebKAIHkRXVHL0rEBqBqKnw9KiEWNLe3KcW54P70nBWwxuscv3FPZHGQ3f0jkZYECruF45lvTNkuRScQK/M4SDw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@reflink/reflink@0.1.19':
+    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
+    engines: {node: '>= 10'}
+
+  pnpm@11.0.0-rc.1:
+    resolution: {integrity: sha512-DX2DdmjrNbgdKPVg747F4QP/XRYuJJ/Q0wxUbDmlUdKQrJzxVwk1O5TS3260Rb+kZcegUUjTKO2jKVDALkDQYA==}
+    engines: {node: '>=22.13'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@11.0.0-rc.1':
+    dependencies:
+      '@reflink/reflink': 0.1.19
+    optionalDependencies:
+      '@pnpm/linux-arm64': 11.0.0-rc.1
+      '@pnpm/linux-x64': 11.0.0-rc.1
+      '@pnpm/macos-arm64': 11.0.0-rc.1
+      '@pnpm/macos-x64': 11.0.0-rc.1
+      '@pnpm/win-arm64': 11.0.0-rc.1
+      '@pnpm/win-x64': 11.0.0-rc.1
+
+  '@pnpm/linux-arm64@11.0.0-rc.1':
+    optional: true
+
+  '@pnpm/linux-x64@11.0.0-rc.1':
+    optional: true
+
+  '@pnpm/macos-arm64@11.0.0-rc.1':
+    optional: true
+
+  '@pnpm/macos-x64@11.0.0-rc.1':
+    optional: true
+
+  '@pnpm/win-arm64@11.0.0-rc.1':
+    optional: true
+
+  '@pnpm/win-x64@11.0.0-rc.1':
+    optional: true
+
+  '@reflink/reflink-darwin-arm64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-darwin-x64@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-arm64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-gnu@0.1.19':
+    optional: true
+
+  '@reflink/reflink-linux-x64-musl@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-arm64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink-win32-x64-msvc@0.1.19':
+    optional: true
+
+  '@reflink/reflink@0.1.19':
+    optionalDependencies:
+      '@reflink/reflink-darwin-arm64': 0.1.19
+      '@reflink/reflink-darwin-x64': 0.1.19
+      '@reflink/reflink-linux-arm64-gnu': 0.1.19
+      '@reflink/reflink-linux-arm64-musl': 0.1.19
+      '@reflink/reflink-linux-x64-gnu': 0.1.19
+      '@reflink/reflink-linux-x64-musl': 0.1.19
+      '@reflink/reflink-win32-arm64-msvc': 0.1.19
+      '@reflink/reflink-win32-x64-msvc': 0.1.19
+
+  pnpm@11.0.0-rc.1: {}
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,1 @@
 minimumReleaseAge: 1440
-minimumReleaseAgeExclude:
-  - hono@4.12.14
-overrides:
-  hono@<4.12.14: '>=4.12.14'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,5 @@
 minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - hono@4.12.14
+overrides:
+  hono@<4.12.14: '>=4.12.14'

--- a/validate.sh
+++ b/validate.sh
@@ -9,7 +9,7 @@ mise install
 # TypeScript
 pnpm install --frozen-lockfile
 pnpm licenses ls
-pnpm audit --fix --ignore-unfixable --ignore-registry-errors
+pnpm audit --fix override --ignore-unfixable
 pnpm exec biome migrate --write
 pnpm run check:write
 pnpm run typecheck

--- a/validate.sh
+++ b/validate.sh
@@ -9,7 +9,7 @@ mise install
 # TypeScript
 pnpm install --frozen-lockfile
 pnpm licenses ls
-pnpm audit --fix override --ignore-unfixable
+pnpm audit --fix update --ignore-unfixable
 pnpm exec biome migrate --write
 pnpm run check:write
 pnpm run typecheck


### PR DESCRIPTION
## Summary

- pnpm を 11.0.0-rc.1 に更新し、廃止された npm audit エンドポイント (410 Gone) の問題を解消
- mise でのインストールを `aqua:pnpm/pnpm` から `npm:pnpm` に変更（11.x のリリースアセット形式変更に対応）
- `pnpm audit --fix override` により hono のセキュリティ脆弱性を修正

🤖 Generated with [Claude Code](https://claude.ai/code)