### PR TITLE
chore: miseのバージョンを .mise.toml の min_version から取得するように変更

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,14 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
-    env:
-      # renovate: datasource=github-releases depName=jdx/mise extractVersion=^v?(?<version>.+)$
-      MISE_VERSION: 2026.4.11
-
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - name: Get mise version from .mise.toml
+        run: echo "MISE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('.mise.toml','rb'))['min_version'])")" >> "$GITHUB_ENV"
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1


### PR DESCRIPTION
## 概要

- ci.yml の `MISE_VERSION` を `.mise.toml` の `min_version` から `tomllib` で取得するように変更
- ワークフロー内のハードコードと Renovate の regex コメントを削除
- `.mise.toml` をバージョンの single source of truth にする

🤖 Generated with [Claude Code](https://claude.com/claude-code)