### PR TITLE
chore: renovate-config-validatorのstrictモードを有効化

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -25,7 +25,7 @@ actionlint
 ghalint run
 
 # Renovate
-renovate-config-validator
+renovate-config-validator --strict
 
 # Check for uncommitted changes
 git diff --exit-code


### PR DESCRIPTION
## 概要

- `validate.sh`の`renovate-config-validator`に`--strict`フラグを追加
- エラーだけでなく、warningやmigration推奨でもバリデーションが失敗するようにする

🤖 Generated with [Claude Code](https://claude.com/claude-code)