### PR TITLE
chore: ビルド不要なdevDependenciesを分離

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN corepack enable && corepack use pnpm && npm install -g bun@${BUN_VERSION}
 
 # Install dependencies
 COPY package.json pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --prod
 
 # Copy source code
 COPY src/ ./src/

--- a/package.json
+++ b/package.json
@@ -24,24 +24,24 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@marp-team/marp-core": "4.3.0",
     "@modelcontextprotocol/ext-apps": "1.6.0",
     "@modelcontextprotocol/sdk": "1.29.0",
-    "cors": "2.8.6",
-    "express": "5.2.1",
-    "get-east-asian-width": "1.5.0",
-    "zod": "4.3.6"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.4.12",
-    "@marp-team/marp-core": "4.3.0",
     "@types/cors": "2.8.19",
     "@types/express": "5.0.6",
     "@types/node": "24.12.2",
     "concurrently": "9.2.1",
+    "cors": "2.8.6",
     "cross-env": "10.1.0",
+    "express": "5.2.1",
+    "get-east-asian-width": "1.5.0",
     "typescript": "6.0.2",
     "vite": "8.0.8",
-    "vite-plugin-singlefile": "2.3.2"
+    "vite-plugin-singlefile": "2.3.2",
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.12"
   },
   "types": "dist/server.d.ts",
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,31 +189,15 @@ importers:
 
   .:
     dependencies:
+      '@marp-team/marp-core':
+        specifier: 4.3.0
+        version: 4.3.0
       '@modelcontextprotocol/ext-apps':
         specifier: 1.6.0
         version: 1.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@4.3.6)
-      cors:
-        specifier: 2.8.6
-        version: 2.8.6
-      express:
-        specifier: 5.2.1
-        version: 5.2.1
-      get-east-asian-width:
-        specifier: 1.5.0
-        version: 1.5.0
-      zod:
-        specifier: 4.3.6
-        version: 4.3.6
-    devDependencies:
-      '@biomejs/biome':
-        specifier: 2.4.12
-        version: 2.4.12
-      '@marp-team/marp-core':
-        specifier: 4.3.0
-        version: 4.3.0
       '@types/cors':
         specifier: 2.8.19
         version: 2.8.19
@@ -226,9 +210,18 @@ importers:
       concurrently:
         specifier: 9.2.1
         version: 9.2.1
+      cors:
+        specifier: 2.8.6
+        version: 2.8.6
       cross-env:
         specifier: 10.1.0
         version: 10.1.0
+      express:
+        specifier: 5.2.1
+        version: 5.2.1
+      get-east-asian-width:
+        specifier: 1.5.0
+        version: 1.5.0
       typescript:
         specifier: 6.0.2
         version: 6.0.2
@@ -238,6 +231,13 @@ importers:
       vite-plugin-singlefile:
         specifier: 2.3.2
         version: 2.3.2(rollup@4.60.1)(vite@8.0.8(@types/node@24.12.2))
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.4.12
+        version: 2.4.12
 
 packages:
 


### PR DESCRIPTION
## 概要

- ビルドに必要なパッケージ（vite、typescript、cross-env等）を`dependencies`に移動
- `devDependencies`にはbiomeのみを残す
- Dockerfileで`pnpm install --frozen-lockfile --prod`にすることで、ビルド時にbiomeを除外

🤖 Generated with [Claude Code](https://claude.com/claude-code)