### PR TITLE
chore: 共有 Renovate プリセットを利用する

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,39 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:best-practices",
-    "customManagers:biomeVersions",
-    "customManagers:dockerfileVersions",
-    "customManagers:githubActionsVersions",
-    "workarounds:nodeDockerVersioning",
-    "workarounds:typesNodeVersioning",
-    ":automergeAll",
-    ":label(dependencies)",
-    ":prConcurrentLimitNone",
-    ":prHourlyLimitNone",
-    ":semanticCommits"
-  ],
-  "ignorePresets": [
-    "security:minimumReleaseAgeNpm",
-    ":maintainLockFilesWeekly"
-  ],
-  "minimumReleaseAge": "1 day",
-  "minimumReleaseAgeBehaviour": "timestamp-optional",
-  "vulnerabilityAlerts": {
-    "enabled": true,
-    "minimumReleaseAge": null
-  },
-  "packageRules": [
-    {
-      "description": "Restrict Node.js to LTS versions",
-      "matchManagers": ["mise"],
-      "matchPackageNames": ["node"],
-      "versioning": "node"
-    },
-    {
-      "description": "Disable automerge for major updates",
-      "matchUpdateTypes": ["major"],
-      "automerge": false
-    }
-  ]
+  "extends": ["github>iwamot/renovate-config#v0.9.0"]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Get mise version from .mise.toml
-        run: echo "MISE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('.mise.toml','rb'))['min_version'])")" >> "$GITHUB_ENV"
+      - name: Get mise version from mise.toml
+        run: echo "MISE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('mise.toml','rb'))['min_version'])")" >> "$GITHUB_ENV"
 
       - name: Setup mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ docker run -p 3001:3001 marp-agent-mcp
 
 ## 開発環境
 
-ツールバージョンは `.mise.toml` で管理。`mise install` で一括セットアップ。
+ツールバージョンは `mise.toml` で管理。`mise install` で一括セットアップ。
 
 ## コミットルール
 

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,6 @@ node = "24.15.0"
 "aqua:suzuki-shunsuke/pinact" = "3.9.0"
 "aqua:zizmorcore/zizmor" = "1.24.1"
 "npm:@marp-team/marp-cli" = "4.3.1"
-"npm:renovate" = "43.123.5"
 
 [tools."npm:pnpm"]
 version = "11.0.0-rc.1"

--- a/validate.sh
+++ b/validate.sh
@@ -24,8 +24,5 @@ zizmor --fix .github/workflows/
 actionlint
 ghalint run
 
-# Renovate
-renovate-config-validator --strict
-
 # Check for uncommitted changes
 git diff --exit-code


### PR DESCRIPTION
## 概要
- 個別の Renovate 設定を `github>iwamot/renovate-config#v0.9.0` に置き換え
- `validate.sh` から `renovate-config-validator` を削除（`iwamot/renovate-config` 側で検証）
- `mise.toml` から `npm:renovate` を削除（不要になったため）
- `.mise.toml` を `mise.toml` にリネーム

🤖 Generated with [Claude Code](https://claude.com/claude-code)