### PR TITLE
chore: 共有 mise tasks を利用する

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>iwamot/renovate-config#v0.9.0"]
+  "extends": ["github>iwamot/renovate-config#v0.10.0"]
 }

--- a/mise.toml
+++ b/mise.toml
@@ -6,13 +6,13 @@ install_before = "1d"
 [tools]
 bun = "1.3.12"
 node = "24.15.0"
-"aqua:hadolint/hadolint" = "2.14.0"
-"aqua:rhysd/actionlint" = "1.7.12"
-"aqua:suzuki-shunsuke/ghalint" = "1.5.5"
-"aqua:suzuki-shunsuke/pinact" = "3.9.0"
-"aqua:zizmorcore/zizmor" = "1.24.1"
 "npm:@marp-team/marp-cli" = "4.3.1"
 
 [tools."npm:pnpm"]
 version = "11.0.0-rc.1"
 install_before = "0d"
+
+[task_config]
+includes = [
+  "git::https://github.com/iwamot/mise-tasks.git//.mise/tasks?ref=v0.10.0",
+]

--- a/validate.sh
+++ b/validate.sh
@@ -15,14 +15,9 @@ pnpm run check:write
 pnpm run typecheck
 pnpm run test
 
-# Dockerfile
-hadolint Dockerfile
-
-# GitHub Actions
-pinact run
-zizmor --fix .github/workflows/
-actionlint
-ghalint run
+# Shared lint tasks
+mise run gha-lint
+mise run docker-lint
 
 # Check for uncommitted changes
 git diff --exit-code


### PR DESCRIPTION
## 概要
- `mise.toml` から aqua 系 lint ツール (actionlint/ghalint/pinact/zizmor/hadolint) を削除
- `[task_config] includes` で `iwamot/mise-tasks` v0.10.0 を参照
- `validate.sh` の GitHub Actions 系・Dockerfile 系を `mise run gha-lint` と `mise run docker-lint` に置換
- `.github/renovate.json` の `extends` を `renovate-config` v0.10.0 にバンプ（shared preset の新機能 — `iwamot/*` の minimumReleaseAge null と `git::` includes 用 custom manager を有効化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)