### PR TITLE
chore: 共有ワークフローを利用する

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,18 +7,4 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
-    steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Enable auto-merge for Dependabot PRs
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr merge --auto --merge "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    uses: iwamot/workflows/.github/workflows/dependabot-auto-merge.yml@abf3e55832d6cc6312c9375a786b13e4021d7007 # v0.5.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,16 +9,4 @@ permissions:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: 'Checkout repository'
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: 'Dependency Review'
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
-        with:
-          comment-summary-in-pr: always
-          license-check: false
-          show-openssf-scorecard: false
+    uses: iwamot/workflows/.github/workflows/dependency-review.yml@abf3e55832d6cc6312c9375a786b13e4021d7007 # v0.5.0

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,36 +20,9 @@ permissions:
 
 jobs:
   renovate:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    environment: production
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        with:
-          client-id: ${{ secrets.RENOVATE_APP_ID }}
-          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
-          permission-contents: write
-          permission-issues: write
-          permission-pull-requests: write
-          permission-vulnerability-alerts: read
-          permission-workflows: write
-          permission-statuses: write
-          permission-checks: write
-
-      - name: Run Renovate
-        uses: renovatebot/github-action@eb932558ad942cccfd8211cf535f17ff183a9f74 # v46.1.9
-        with:
-          configurationFile: .github/renovate.json
-          token: ${{ steps.app-token.outputs.token }}
-        env:
-          LOG_LEVEL: ${{ inputs.log-level || 'info' }}
-          RENOVATE_REPOSITORIES: ${{ github.repository }}
+    uses: iwamot/workflows/.github/workflows/renovate.yml@abf3e55832d6cc6312c9375a786b13e4021d7007 # v0.5.0
+    with:
+      log-level: ${{ inputs.log-level || 'info' }}
+    secrets:
+      RENOVATE_APP_ID: ${{ secrets.RENOVATE_APP_ID }}
+      RENOVATE_PRIVATE_KEY: ${{ secrets.RENOVATE_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- dependency-review / dependabot-auto-merge / renovate のインラインステップ定義を `iwamot/workflows@v0.5.0` の再利用可能ワークフローの呼び出しに置き換え
- renovate 側では workflow_dispatch の `log-level` をそのまま引き渡し、GitHub App シークレット（`RENOVATE_APP_ID`, `RENOVATE_PRIVATE_KEY`）は `secrets:` ブロックで明示的に渡す