### PR TITLE
chore: 共有 ci ワークフローを利用し、共有ワークフロー群を v0.8.0 に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,25 +10,5 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Run Linting, Type Check, and Tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Get mise version from mise.toml
-        run: echo "MISE_VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('mise.toml','rb'))['min_version'])")" >> "$GITHUB_ENV"
-
-      - name: Setup mise
-        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
-        with:
-          version: ${{ env.MISE_VERSION }}
-
-      - name: Run validation script
-        run: bash validate.sh
+  ci:
+    uses: iwamot/workflows/.github/workflows/ci.yml@ddd824917bcf31b58113e4f8b14421436146bc17 # v0.8.0

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,5 +6,5 @@ permissions:
   pull-requests: write
 
 jobs:
-  dependabot:
-    uses: iwamot/workflows/.github/workflows/dependabot-auto-merge.yml@3926091bedbf975210db444221da3bc5e3620492 # v0.7.1
+  dependabot-auto-merge:
+    uses: iwamot/workflows/.github/workflows/dependabot-auto-merge.yml@ddd824917bcf31b58113e4f8b14421436146bc17 # v0.8.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   dependency-review:
-    uses: iwamot/workflows/.github/workflows/dependency-review.yml@3926091bedbf975210db444221da3bc5e3620492 # v0.7.1
+    uses: iwamot/workflows/.github/workflows/dependency-review.yml@ddd824917bcf31b58113e4f8b14421436146bc17 # v0.8.0

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   renovate:
-    uses: iwamot/workflows/.github/workflows/renovate.yml@3926091bedbf975210db444221da3bc5e3620492 # v0.7.1
+    uses: iwamot/workflows/.github/workflows/renovate.yml@ddd824917bcf31b58113e4f8b14421436146bc17 # v0.8.0
     with:
       log-level: ${{ inputs.log-level || 'info' }}
     secrets:


### PR DESCRIPTION
## Summary

- `ci.yml` をインライン定義から `iwamot/workflows@v0.8.0` の再利用可能ワークフロー呼び出しに変更
- 他 3 ワークフロー（dependabot-auto-merge / dependency-review / renovate）を v0.7.1 から v0.8.0 へ bump
- v0.8.0 での job id リネームに合わせて caller 側の job id も揃える：
  - `ci.yml`: 新 caller、`jobs.ci`
  - `dependabot-auto-merge.yml`: `dependabot` → `dependabot-auto-merge`

## Follow-up

マージ後に branch protection の required-status-check を更新：
- (新規) `ci / ci`
- `dependabot / dependabot` → `dependabot-auto-merge / dependabot-auto-merge`