### PR TITLE
chore: add release.yml for auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: 🏕 Features
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: 👒 Dependencies
+      labels:
+        - dependencies


### PR DESCRIPTION
## Summary
- GitHub の自動生成リリースノートを Features / Dependencies にカテゴライズする設定を追加
- 他の iwamot 系リポジトリ (collmbo 等) と揃えた内容