### PR TITLE
chore(deps): remove pnpm install_before override

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -6,11 +6,8 @@ install_before = "1d"
 [tools]
 bun = "1.3.12"
 node = "24.15.0"
+"npm:pnpm" = "11.0.0-rc.2"
 "npm:@marp-team/marp-cli" = "4.3.1"
-
-[tools."npm:pnpm"]
-version = "11.0.0-rc.2"
-install_before = "0d"
 
 [task_config]
 includes = [


### PR DESCRIPTION
## Summary

- Removed the per-tool `install_before = "0d"` override for `npm:pnpm` in `mise.toml`.
- More than a day has passed since `pnpm@11.0.0-rc.2` was released, so the top-level `install_before = "1d"` constraint is now satisfied without the override.
- `npm:pnpm = "11.0.0-rc.2"` now lives in the regular `[tools]` table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)