### PR TITLE
fix(deps): @xmldom/xmldom を 0.9.10 に override して脆弱性を解消

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@xmldom/xmldom': 0.9.10
+
 importers:
 
   .:
@@ -521,10 +524,9 @@ packages:
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
-  '@xmldom/xmldom@0.9.9':
-    resolution: {integrity: sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==}
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
-    deprecated: this version has critical issues, please update to the latest version
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -1530,7 +1532,7 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 24.12.2
 
-  '@xmldom/xmldom@0.9.9': {}
+  '@xmldom/xmldom@0.9.10': {}
 
   accepts@2.0.0:
     dependencies:
@@ -2116,7 +2118,7 @@ snapshots:
 
   speech-rule-engine@4.1.3:
     dependencies:
-      '@xmldom/xmldom': 0.9.9
+      '@xmldom/xmldom': 0.9.10
       commander: 13.1.0
       wicked-good-xpath: 1.3.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,5 @@
 minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@xmldom/xmldom@0.9.10'
+overrides:
+  '@xmldom/xmldom': 0.9.10


### PR DESCRIPTION
## Summary

- `speech-rule-engine@4.1.3` が `@xmldom/xmldom@0.9.9` を完全固定で依存しており、4件の high severity 脆弱性（DoS / XML injection 系）が残っていた
- pnpm の `overrides` で `@xmldom/xmldom` を 0.9.10 に強制置換
- `minimumReleaseAgeExclude` は `pnpm audit --fix` が自動追加した行。24h 経過後は削除可能

upstream の speech-rule-engine が `^0.9.10` 以上に追従すれば、両設定とも削除できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)