### PR TITLE
fix: Docker build で pnpm-workspace.yaml を COPY し overrides 整合性エラーを解消

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ARG BUN_VERSION=1.3.13
 RUN corepack enable && corepack use pnpm && npm install -g bun@${BUN_VERSION}
 
 # Install dependencies
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile --prod
 
 # Copy source code

--- a/package.json
+++ b/package.json
@@ -52,10 +52,5 @@
   },
   "bin": {
     "marp-agent-mcp": "dist/index.js"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
   }
 }


### PR DESCRIPTION
## Summary

- xmldom override 追加 (0e34b7d) 以降、`docker build --no-cache` が `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` で失敗していた問題を修正
- `pnpm-workspace.yaml` を Docker の COPY 対象に加え、pnpm の overrides 整合性チェックを通す
- あわせて、vite 8 の rolldown 化で依存ツリーから消えていた `pnpm.onlyBuiltDependencies` の `esbuild` 設定を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)