### PR TITLE
chore: aube を npm バックエンドに切り替え

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,10 +4,13 @@ min_version = "2026.4.17"
 install_before = "1d"
 
 [tools]
-aube = "1.0.0"
 bun = "1.3.13"
 node = "24.15.0"
 "npm:@marp-team/marp-cli" = "4.3.1"
+
+[tools."npm:@endevco/aube"]
+version = "1.0.0"
+install_before = "0d"
 
 [task_config]
 includes = [


### PR DESCRIPTION
## Summary

- mise.toml で aube を GitHub Releases バックエンドから npm バックエンド（`"npm:@endevco/aube"`）に切り替え
- Dockerfile と同じ npm パッケージ (`@endevco/aube`) を参照する形にしてソースを統一
- Renovate の npm datasource で追跡されるようになる

## install_before の上書きについて

`[tools."npm:@endevco/aube"]` セクションで `install_before = "0d"` を明示。全体ポリシー `1d` では aube 1.0.0 の公開直後（<24h）に `ETARGET` で弾かれるため。Dockerfile 側で既に同じ npm レジストリから即時取得しているので、mise 側も整合させる。

## core plugin があるツール（bun / node）について

bun は mise core plugin で既に Renovate に検出されているため、npm バックエンドに寄せる必要はなし。「core plugin があればそちら、無ければ npm 等に寄せる」という方針で統一。