### PR TITLE
chore: overrides を package.json に集約し postcss 脆弱性に対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,9 @@
   },
   "bin": {
     "marp-agent-mcp": "dist/index.js"
+  },
+  "overrides": {
+    "@xmldom/xmldom": "0.9.10",
+    "postcss": "8.5.10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,184 +1,3 @@
----
-lockfileVersion: '9.0'
-
-importers:
-
-  .:
-    configDependencies: {}
-    packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 11.0.0-rc.1
-        version: 11.0.0-rc.1
-      pnpm:
-        specifier: 11.0.0-rc.1
-        version: 11.0.0-rc.1
-
-packages:
-
-  '@pnpm/exe@11.0.0-rc.1':
-    resolution: {integrity: sha512-nGmEQeq3w+zHDtbnsdj69EaW78UkHwIeNR9uOx893JasG3boZuiFUugwOKpQIDfMBDFK+32SDMLyqDjuaSp/ZQ==}
-    hasBin: true
-
-  '@pnpm/linux-arm64@11.0.0-rc.1':
-    resolution: {integrity: sha512-HJY94Zz6IEc55kPoMB+ocXWWUmqrHohwN3gxMFfFODWpKUYsNvheFJxpTRn6wIZj7n7pYSVxdGZjDvzedbeuoQ==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@pnpm/linux-x64@11.0.0-rc.1':
-    resolution: {integrity: sha512-UIGMWTZqlYaTS4EjHMX1xEgwlBfW8aKCu85kZMEcFsO08S++3F7Au09fa4t+MbjeaVcgz8LSGA1zf5nqY/uK1w==}
-    cpu: [x64]
-    os: [linux]
-
-  '@pnpm/macos-arm64@11.0.0-rc.1':
-    resolution: {integrity: sha512-+LC41cEalZMUCrDDNyQ2a/krK7cn6WnKDlZDBkiLVqZInfW8c31yAYIEPdkesVRudr7lneFSEP/I3AkcpsBJdQ==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@pnpm/macos-x64@11.0.0-rc.1':
-    resolution: {integrity: sha512-vMccaVqCCkldd3QywMc48R1wQMnXBzE13kCHu5hKTd8NLJgHOrnXsN9Qt7jj3T9WT4zRjfbfua7HzGX9ZYR02A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@pnpm/win-arm64@11.0.0-rc.1':
-    resolution: {integrity: sha512-5GMjLMefmzgsIHYparaGwwNuFrtFXO5xpbA0MBT+kCYtNqy1ORGsoU0jjhKMmxcuBj6L/P7X21Zfhzc7CudeoA==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@pnpm/win-x64@11.0.0-rc.1':
-    resolution: {integrity: sha512-ebKAIHkRXVHL0rEBqBqKnw9KiEWNLe3KcW54P70nBWwxuscv3FPZHGQ3f0jkZYECruF45lvTNkuRScQK/M4SDw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink@0.1.19':
-    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
-    engines: {node: '>= 10'}
-
-  pnpm@11.0.0-rc.1:
-    resolution: {integrity: sha512-DX2DdmjrNbgdKPVg747F4QP/XRYuJJ/Q0wxUbDmlUdKQrJzxVwk1O5TS3260Rb+kZcegUUjTKO2jKVDALkDQYA==}
-    engines: {node: '>=22.13'}
-    hasBin: true
-
-snapshots:
-
-  '@pnpm/exe@11.0.0-rc.1':
-    dependencies:
-      '@reflink/reflink': 0.1.19
-    optionalDependencies:
-      '@pnpm/linux-arm64': 11.0.0-rc.1
-      '@pnpm/linux-x64': 11.0.0-rc.1
-      '@pnpm/macos-arm64': 11.0.0-rc.1
-      '@pnpm/macos-x64': 11.0.0-rc.1
-      '@pnpm/win-arm64': 11.0.0-rc.1
-      '@pnpm/win-x64': 11.0.0-rc.1
-
-  '@pnpm/linux-arm64@11.0.0-rc.1':
-    optional: true
-
-  '@pnpm/linux-x64@11.0.0-rc.1':
-    optional: true
-
-  '@pnpm/macos-arm64@11.0.0-rc.1':
-    optional: true
-
-  '@pnpm/macos-x64@11.0.0-rc.1':
-    optional: true
-
-  '@pnpm/win-arm64@11.0.0-rc.1':
-    optional: true
-
-  '@pnpm/win-x64@11.0.0-rc.1':
-    optional: true
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink@0.1.19':
-    optionalDependencies:
-      '@reflink/reflink-darwin-arm64': 0.1.19
-      '@reflink/reflink-darwin-x64': 0.1.19
-      '@reflink/reflink-linux-arm64-gnu': 0.1.19
-      '@reflink/reflink-linux-arm64-musl': 0.1.19
-      '@reflink/reflink-linux-x64-gnu': 0.1.19
-      '@reflink/reflink-linux-x64-musl': 0.1.19
-      '@reflink/reflink-win32-arm64-msvc': 0.1.19
-      '@reflink/reflink-win32-x64-msvc': 0.1.19
-
-  pnpm@11.0.0-rc.1: {}
-
----
 lockfileVersion: '9.0'
 
 settings:
@@ -187,6 +6,223 @@ settings:
 
 overrides:
   '@xmldom/xmldom': 0.9.10
+  postcss: 8.5.10
+
+time:
+  '@biomejs/biome@2.4.12': 2026-04-14T18:20:56.934Z
+  '@biomejs/cli-darwin-arm64@2.4.12': 2026-04-14T18:21:03.782Z
+  '@biomejs/cli-linux-arm64-musl@2.4.12': 2026-04-14T18:21:25.926Z
+  '@biomejs/cli-linux-arm64@2.4.12': 2026-04-14T18:21:18.962Z
+  '@biomejs/cli-linux-x64-musl@2.4.12': 2026-04-14T18:21:41.870Z
+  '@biomejs/cli-linux-x64@2.4.12': 2026-04-14T18:21:33.920Z
+  '@biomejs/cli-win32-arm64@2.4.12': 2026-04-14T18:21:49.226Z
+  '@biomejs/cli-win32-x64@2.4.12': 2026-04-14T18:21:57.980Z
+  '@csstools/postcss-is-pseudo-class@5.0.3': 2025-06-11T10:37:31.892Z
+  '@csstools/selector-resolve-nested@3.1.0': 2025-06-06T09:57:24.889Z
+  '@csstools/selector-specificity@5.0.0': 2024-10-23T21:44:00.675Z
+  '@epic-web/invariant@1.0.0': 2023-12-14T00:28:05.418Z
+  '@hono/node-server@1.19.14': 2026-04-13T01:20:00.328Z
+  '@marp-team/marp-core@4.3.0': 2026-02-28T19:15:13.725Z
+  '@marp-team/marpit-svg-polyfill@2.1.0': 2023-02-10T10:56:19.299Z
+  '@marp-team/marpit@3.2.1': 2026-02-28T17:23:24.136Z
+  '@modelcontextprotocol/ext-apps@1.7.0': 2026-04-21T15:22:13.736Z
+  '@modelcontextprotocol/sdk@1.29.0': 2026-03-30T16:50:42.718Z
+  '@oxc-project/types@0.127.0': 2026-04-20T19:31:02.662Z
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17': 2026-04-22T11:13:47.749Z
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17': 2026-04-22T11:13:42.623Z
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17': 2026-04-22T11:13:53.598Z
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17': 2026-04-22T11:13:18.886Z
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17': 2026-04-22T11:13:25.244Z
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17': 2026-04-22T11:14:04.463Z
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17': 2026-04-22T11:13:13.128Z
+  '@rolldown/pluginutils@1.0.0-rc.17': 2026-04-22T11:13:01.300Z
+  '@standard-schema/spec@1.1.0': 2025-12-15T20:49:46.431Z
+  '@types/body-parser@1.19.6': 2025-06-07T02:15:26.399Z
+  '@types/connect@3.4.38': 2023-11-07T00:57:34.681Z
+  '@types/cors@2.8.19': 2025-06-07T02:16:26.348Z
+  '@types/express-serve-static-core@5.1.1': 2026-01-10T09:35:12.712Z
+  '@types/express@5.0.6': 2025-12-01T20:35:51.488Z
+  '@types/http-errors@2.0.5': 2025-06-07T02:17:33.428Z
+  '@types/node@24.12.2': 2026-04-03T11:15:02.599Z
+  '@types/qs@6.15.0': 2026-03-06T02:55:59.542Z
+  '@types/range-parser@1.2.7': 2023-11-07T13:45:22.371Z
+  '@types/send@1.2.1': 2025-10-24T04:37:36.382Z
+  '@types/serve-static@2.2.0': 2025-10-27T20:36:09.811Z
+  '@xmldom/xmldom@0.9.10': 2026-04-18T11:34:10.031Z
+  accepts@2.0.0: 2024-08-31T15:50:05.694Z
+  ajv-formats@3.0.1: 2024-03-30T11:30:26.728Z
+  ajv@8.18.0: 2026-02-14T15:41:17.656Z
+  ansi-regex@5.0.1: 2021-09-14T15:55:19.540Z
+  ansi-styles@4.3.0: 2020-10-04T19:18:25.986Z
+  argparse@2.0.1: 2020-08-28T21:14:26.713Z
+  async-function@1.0.0: 2025-01-23T03:15:54.266Z
+  async-generator-function@1.0.0: 2025-02-14T18:35:17.106Z
+  body-parser@2.2.2: 2026-01-07T09:38:34.589Z
+  braces@3.0.3: 2024-05-21T08:59:11.390Z
+  bytes@3.1.2: 2022-01-28T05:02:37.661Z
+  call-bind-apply-helpers@1.0.2: 2025-02-12T19:24:56.950Z
+  call-bound@1.0.4: 2025-03-03T17:50:03.505Z
+  chalk@4.1.2: 2021-07-30T12:02:52.839Z
+  cliui@8.0.1: 2022-10-01T01:16:14.782Z
+  color-convert@2.0.1: 2019-08-19T21:05:36.605Z
+  color-name@1.1.4: 2018-09-21T10:48:56.546Z
+  commander@13.1.0: 2025-01-20T23:29:10.201Z
+  commander@2.20.3: 2019-10-11T05:40:24.166Z
+  commander@8.3.0: 2021-10-22T07:02:06.771Z
+  concurrently@9.2.1: 2025-08-25T09:50:49.138Z
+  content-disposition@1.1.0: 2026-04-07T21:07:53.748Z
+  content-type@1.0.5: 2023-01-29T19:25:59.622Z
+  cookie-signature@1.2.2: 2024-10-29T19:39:47.642Z
+  cookie@0.7.2: 2024-10-07T03:41:28.828Z
+  cors@2.8.6: 2026-01-22T14:41:30.223Z
+  cross-env@10.1.0: 2025-09-29T17:34:12.232Z
+  cross-spawn@7.0.6: 2024-11-18T13:59:52.129Z
+  cssesc@3.0.0: 2019-02-04T16:34:20.250Z
+  cssfilter@0.0.10: 2017-02-01T02:51:18.200Z
+  debug@4.4.3: 2025-09-13T17:25:19.732Z
+  depd@2.0.0: 2018-10-26T17:52:55.936Z
+  detect-libc@2.1.2: 2025-10-05T12:46:33.077Z
+  dunder-proto@1.0.1: 2024-12-17T02:12:47.047Z
+  ee-first@1.1.1: 2015-05-25T19:18:28.732Z
+  emoji-regex@8.0.0: 2019-03-05T18:58:23.040Z
+  encodeurl@2.0.0: 2024-03-29T00:03:42.135Z
+  entities@4.5.0: 2023-04-13T17:57:56.308Z
+  es-define-property@1.0.1: 2024-12-06T18:16:02.148Z
+  es-errors@1.3.0: 2024-02-05T08:05:51.479Z
+  es-object-atoms@1.1.1: 2025-01-15T00:42:43.342Z
+  escalade@3.2.0: 2024-08-29T22:59:36.690Z
+  escape-html@1.0.3: 2015-09-01T04:47:22.713Z
+  esm@3.2.25: 2019-05-17T05:24:41.368Z
+  etag@1.8.1: 2017-09-13T02:43:44.422Z
+  eventsource-parser@3.0.8: 2026-04-19T17:45:17.687Z
+  eventsource@3.0.7: 2025-05-09T10:32:51.243Z
+  express-rate-limit@8.4.0: 2026-04-23T03:20:11.300Z
+  express@5.2.1: 2025-12-01T20:49:43.268Z
+  fast-deep-equal@3.1.3: 2020-06-08T07:27:28.474Z
+  fast-uri@3.1.0: 2025-08-25T13:16:04.404Z
+  fdir@6.5.0: 2025-08-14T16:56:03.948Z
+  fill-range@7.1.1: 2024-05-21T08:45:51.224Z
+  finalhandler@2.1.1: 2025-12-01T16:05:02.140Z
+  forwarded@0.2.0: 2021-05-31T23:23:02.495Z
+  fresh@2.0.0: 2024-09-04T23:24:48.361Z
+  fsevents@2.3.3: 2023-08-21T16:24:22.854Z
+  function-bind@1.1.2: 2023-10-12T19:08:19.687Z
+  generator-function@2.0.1: 2025-09-30T18:23:33.207Z
+  get-caller-file@2.0.5: 2019-03-09T21:48:30.527Z
+  get-east-asian-width@1.5.0: 2026-02-18T16:34:54.366Z
+  get-intrinsic@1.3.1: 2025-09-29T23:20:07.570Z
+  get-proto@1.0.1: 2025-01-02T20:08:02.949Z
+  gopd@1.2.0: 2024-12-04T16:21:52.727Z
+  has-flag@4.0.0: 2019-04-06T15:49:21.907Z
+  has-symbols@1.1.0: 2024-12-02T16:34:17.679Z
+  hasown@2.0.3: 2026-04-17T22:12:06.275Z
+  highlight.js@11.11.1: 2024-12-25T17:53:19.490Z
+  hono@4.12.14: 2026-04-15T06:13:54.430Z
+  http-errors@2.0.1: 2025-11-20T19:12:22.755Z
+  iconv-lite@0.7.2: 2026-01-08T16:49:11.167Z
+  inherits@2.0.4: 2019-06-19T20:18:52.465Z
+  ip-address@10.1.0: 2025-11-08T19:50:45.900Z
+  ipaddr.js@1.9.1: 2019-07-17T02:28:19.618Z
+  is-fullwidth-code-point@3.0.0: 2019-03-18T08:09:05.035Z
+  is-number@7.0.0: 2018-07-04T15:08:58.238Z
+  is-promise@4.0.0: 2020-04-27T15:34:23.345Z
+  isexe@2.0.0: 2017-03-23T00:53:16.356Z
+  jose@6.2.2: 2026-03-18T21:27:57.662Z
+  js-yaml@4.1.1: 2025-11-12T15:18:03.524Z
+  json-schema-traverse@1.0.0: 2020-12-13T10:56:54.719Z
+  json-schema-typed@8.0.2: 2025-11-17T20:30:24.942Z
+  katex@0.16.45: 2026-04-05T13:32:39.675Z
+  lightningcss-darwin-arm64@1.32.0: 2026-03-09T04:23:07.357Z
+  lightningcss-linux-arm64-gnu@1.32.0: 2026-03-09T04:23:18.594Z
+  lightningcss-linux-arm64-musl@1.32.0: 2026-03-09T04:23:21.203Z
+  lightningcss-linux-x64-gnu@1.32.0: 2026-03-09T04:23:24.274Z
+  lightningcss-linux-x64-musl@1.32.0: 2026-03-09T04:23:27.400Z
+  lightningcss-win32-arm64-msvc@1.32.0: 2026-03-09T04:23:30.176Z
+  lightningcss-win32-x64-msvc@1.32.0: 2026-03-09T04:23:33.073Z
+  lightningcss@1.32.0: 2026-03-09T04:23:43.754Z
+  linkify-it@5.0.0: 2023-12-01T21:47:27.805Z
+  lodash.kebabcase@4.1.1: 2016-08-13T17:41:29.425Z
+  markdown-it-front-matter@0.2.4: 2024-04-04T04:27:52.788Z
+  markdown-it@14.1.1: 2026-02-11T03:49:52.301Z
+  math-intrinsics@1.1.0: 2024-12-19T05:58:09.877Z
+  mathjax-full@3.2.2: 2022-06-08T17:29:04.841Z
+  mdurl@2.0.0: 2023-12-01T05:03:40.542Z
+  media-typer@1.1.0: 2019-04-25T03:16:05.379Z
+  merge-descriptors@2.0.0: 2023-11-16T18:49:20.714Z
+  mhchemparser@4.2.1: 2023-05-24T08:17:06.027Z
+  micromatch@4.0.8: 2024-08-23T16:31:18.748Z
+  mime-db@1.54.0: 2025-03-18T15:06:44.354Z
+  mime-types@3.0.2: 2025-11-20T11:12:29.693Z
+  mj-context-menu@0.6.1: 2020-08-20T10:50:52.317Z
+  ms@2.1.3: 2020-12-08T13:54:35.223Z
+  nanoid@3.3.11: 2025-03-18T23:06:32.923Z
+  negotiator@1.0.0: 2024-08-31T15:42:18.280Z
+  object-assign@4.1.1: 2017-01-16T15:35:15.282Z
+  object-inspect@1.13.4: 2025-02-05T01:26:10.272Z
+  on-finished@2.4.1: 2022-02-22T16:10:48.714Z
+  once@1.4.0: 2016-09-06T21:11:09.367Z
+  parseurl@1.3.3: 2019-04-16T04:16:26.547Z
+  path-key@3.1.1: 2019-11-22T16:47:18.153Z
+  path-to-regexp@8.4.2: 2026-04-01T21:17:05.201Z
+  picocolors@1.1.1: 2024-10-16T18:20:03.921Z
+  picomatch@2.3.2: 2026-03-23T20:39:08.118Z
+  picomatch@4.0.4: 2026-03-23T20:39:47.960Z
+  pkce-challenge@5.0.1: 2025-11-23T03:54:38.460Z
+  postcss-nesting@13.0.2: 2025-06-10T10:04:18.922Z
+  postcss-selector-parser@7.1.1: 2025-11-27T14:35:17.807Z
+  postcss@8.5.10: 2026-04-15T14:42:53.378Z
+  proxy-addr@2.0.7: 2021-06-01T00:57:28.507Z
+  punycode.js@2.3.1: 2023-10-30T18:28:36.491Z
+  qs@6.15.1: 2026-04-08T19:37:55.541Z
+  range-parser@1.2.1: 2019-05-11T00:27:37.805Z
+  raw-body@3.0.2: 2025-11-21T20:47:27.523Z
+  require-directory@2.1.1: 2015-05-28T08:31:04.702Z
+  require-from-string@2.0.2: 2018-04-09T09:49:47.301Z
+  rolldown@1.0.0-rc.17: 2026-04-22T11:14:29.632Z
+  router@2.2.0: 2025-03-27T00:38:18.615Z
+  rxjs@7.8.2: 2025-02-22T03:00:42.711Z
+  safer-buffer@2.1.2: 2018-04-08T10:42:42.130Z
+  send@1.2.1: 2025-12-15T19:36:11.862Z
+  serve-static@2.2.1: 2025-12-15T19:17:31.514Z
+  setprototypeof@1.2.0: 2019-07-18T04:49:56.614Z
+  shebang-command@2.0.0: 2019-09-06T14:53:25.901Z
+  shebang-regex@3.0.0: 2019-04-27T10:46:19.256Z
+  shell-quote@1.8.3: 2025-06-02T05:03:05.889Z
+  side-channel-list@1.0.1: 2026-04-08T16:55:13.603Z
+  side-channel-map@1.0.1: 2024-12-11T04:53:18.943Z
+  side-channel-weakmap@1.0.2: 2024-12-11T05:39:11.495Z
+  side-channel@1.1.0: 2024-12-11T17:00:33.553Z
+  source-map-js@1.2.1: 2024-09-08T16:22:55.645Z
+  speech-rule-engine@4.1.4: 2026-04-22T13:50:27.137Z
+  statuses@2.0.2: 2025-06-06T19:56:01.385Z
+  string-width@4.2.3: 2021-09-23T17:17:21.341Z
+  strip-ansi@6.0.1: 2021-09-23T16:34:41.798Z
+  supports-color@7.2.0: 2020-08-28T11:17:34.870Z
+  supports-color@8.1.1: 2021-01-23T09:21:36.393Z
+  tinyglobby@0.2.16: 2026-04-07T23:37:03.457Z
+  to-regex-range@5.0.1: 2019-04-07T06:04:37.030Z
+  toidentifier@1.0.1: 2021-11-14T22:19:09.631Z
+  tree-kill@1.2.2: 2019-12-11T18:34:21.876Z
+  tslib@2.8.1: 2024-10-31T22:42:48.624Z
+  type-is@2.0.1: 2025-03-27T01:20:01.576Z
+  typescript@6.0.3: 2026-04-16T23:38:27.905Z
+  uc.micro@2.1.0: 2024-03-02T17:44:53.816Z
+  undici-types@7.16.0: 2025-09-09T17:07:27.610Z
+  unpipe@1.0.0: 2015-06-14T20:30:19.934Z
+  util-deprecate@1.0.2: 2015-10-07T18:37:40.665Z
+  vary@1.1.2: 2017-09-24T01:47:11.325Z
+  vite-plugin-singlefile@2.3.3: 2026-04-17T22:28:03.802Z
+  vite@8.0.10: 2026-04-23T05:19:36.436Z
+  which@2.0.2: 2019-11-18T22:26:15.325Z
+  wicked-good-xpath@1.3.0: 2016-04-01T09:11:19.912Z
+  wrap-ansi@7.0.0: 2020-04-22T16:53:23.889Z
+  wrappy@1.0.2: 2016-05-17T23:30:52.415Z
+  xss@1.0.15: 2024-03-03T02:33:54.727Z
+  y18n@5.0.8: 2021-04-07T18:57:33.969Z
+  yargs-parser@21.1.1: 2022-08-04T21:13:43.411Z
+  yargs@17.7.2: 2023-04-27T19:59:02.861Z
+  zod-to-json-schema@3.25.2: 2026-03-27T07:09:39.645Z
+  zod@4.3.6: 2026-01-22T19:14:35.382Z
 
 importers:
 
@@ -195,6 +231,9 @@ importers:
       '@marp-team/marp-core':
         specifier: 4.3.0
         version: 4.3.0
+      '@marp-team/marpit':
+        specifier: '>=0.5.0'
+        version: 3.2.1
       '@modelcontextprotocol/ext-apps':
         specifier: 1.7.0
         version: 1.7.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)
@@ -210,6 +249,9 @@ importers:
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
+      ajv:
+        specifier: ^8.0.0
+        version: 8.18.0
       concurrently:
         specifier: 9.2.1
         version: 9.2.1
@@ -225,6 +267,18 @@ importers:
       get-east-asian-width:
         specifier: 1.5.0
         version: 1.5.0
+      hono:
+        specifier: ^4
+        version: 4.12.14
+      picomatch:
+        specifier: ^3 || ^4
+        version: 4.0.4
+      postcss:
+        specifier: ^8.4
+        version: 8.5.10
+      postcss-selector-parser:
+        specifier: ^7.0.0
+        version: 7.1.1
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -252,54 +306,66 @@ packages:
   '@biomejs/cli-darwin-arm64@2.4.12':
     resolution: {integrity: sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng==}
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@biomejs/cli-darwin-x64@2.4.12':
-    resolution: {integrity: sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A==}
-    engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [darwin]
+    os:
+    - darwin
+    cpu:
+    - arm64
 
   '@biomejs/cli-linux-arm64-musl@2.4.12':
     resolution: {integrity: sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig==}
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
 
   '@biomejs/cli-linux-arm64@2.4.12':
     resolution: {integrity: sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==}
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
 
   '@biomejs/cli-linux-x64-musl@2.4.12':
     resolution: {integrity: sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==}
     engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
 
   '@biomejs/cli-linux-x64@2.4.12':
     resolution: {integrity: sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==}
     engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
 
   '@biomejs/cli-win32-arm64@2.4.12':
     resolution: {integrity: sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==}
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - arm64
 
   '@biomejs/cli-win32-x64@2.4.12':
     resolution: {integrity: sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA==}
     engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - x64
 
   '@csstools/postcss-is-pseudo-class@5.0.3':
     resolution: {integrity: sha512-jS/TY4SpG4gszAtIg7Qnf3AS2pjcUM5SzxpApOrlndMeGhIbaTzWBzzP/IApXoNWEW7OhcjkRT48jnAUIFXhAQ==}
@@ -319,20 +385,11 @@ packages:
     peerDependencies:
       postcss-selector-parser: ^7.0.0
 
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
-
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
-
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
-  '@hono/node-server@1.19.13':
-    resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -377,119 +434,80 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
-
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+      zod: {}
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
+    os:
+    - darwin
+    cpu:
+    - arm64
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
-    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - arm64
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - x64
 
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -554,6 +572,14 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  async-function@1.0.0:
+    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
+    engines: {node: '>= 0.4'}
+
+  async-generator-function@1.0.0:
+    resolution: {integrity: sha512-+NAXNqgCrB95ya4Sr66i1CL2hqLVckAk7xwRYWdcm39/ELQ6YNn1aw5r0bdQtqNZgQpEWzc5yc/igXc7aL5SLA==}
+    engines: {node: '>= 0.4'}
+
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
@@ -605,8 +631,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  content-disposition@1.0.1:
-    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
     engines: {node: '>=18'}
 
   content-type@1.0.5:
@@ -645,8 +671,6 @@ packages:
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
@@ -704,16 +728,16 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
 
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  express-rate-limit@8.3.2:
-    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+  express-rate-limit@8.4.0:
+    resolution: {integrity: sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -756,10 +780,15 @@ packages:
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
+    os:
+    - darwin
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -769,8 +798,8 @@ packages:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
 
-  get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+  get-intrinsic@1.3.1:
+    resolution: {integrity: sha512-fk1ZVEeOX9hVZ6QzoBNEC55+Ucqg4sTVwrVuigZhuRPESVFpMyXnd3sbXvPOwp7Y9riVyANiqhEuRF0G1aVSeQ==}
     engines: {node: '>= 0.4'}
 
   get-proto@1.0.1:
@@ -789,8 +818,8 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
   highlight.js@11.11.1:
@@ -851,75 +880,69 @@ packages:
     resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
     hasBin: true
 
-  lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [android]
-
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm]
-    os: [linux]
+    os:
+    - darwin
+    cpu:
+    - arm64
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - arm64
 
   lightningcss-win32-x64-msvc@1.32.0:
     resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
     engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - x64
 
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
@@ -944,7 +967,6 @@ packages:
 
   mathjax-full@3.2.2:
     resolution: {integrity: sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==}
-    deprecated: Version 4 replaces this package with the scoped package @mathjax/src
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -1042,10 +1064,6 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
-    engines: {node: ^10 || ^12 || >=14}
-
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -1054,8 +1072,8 @@ packages:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.1:
@@ -1112,8 +1130,8 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
@@ -1132,8 +1150,8 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  speech-rule-engine@4.1.3:
-    resolution: {integrity: sha512-SBMgkuJYvP4F62daRfBNwYC2nXTEhNXAfsBZ/BB7Ly85/KnbnjmKM7/45ZrFbH6jIMiAliDUDPSZFUuXDvcg6A==}
+  speech-rule-engine@4.1.4:
+    resolution: {integrity: sha512-i/VCLG1fvRc95pMHRqG4aQNscv+9aIsqA2oI7ZQS51sTdUcDHYX6cpT8/tqZ+enjs1tKVwbRBWgxut9SWn+f9g==}
     hasBin: true
 
   statuses@2.0.2:
@@ -1299,7 +1317,6 @@ snapshots:
   '@biomejs/biome@2.4.12':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.4.12
-      '@biomejs/cli-darwin-x64': 2.4.12
       '@biomejs/cli-linux-arm64': 2.4.12
       '@biomejs/cli-linux-arm64-musl': 2.4.12
       '@biomejs/cli-linux-x64': 2.4.12
@@ -1307,34 +1324,24 @@ snapshots:
       '@biomejs/cli-win32-arm64': 2.4.12
       '@biomejs/cli-win32-x64': 2.4.12
 
-  '@biomejs/cli-darwin-arm64@2.4.12':
-    optional: true
+  '@biomejs/cli-darwin-arm64@2.4.12': {}
 
-  '@biomejs/cli-darwin-x64@2.4.12':
-    optional: true
+  '@biomejs/cli-linux-arm64-musl@2.4.12': {}
 
-  '@biomejs/cli-linux-arm64-musl@2.4.12':
-    optional: true
+  '@biomejs/cli-linux-arm64@2.4.12': {}
 
-  '@biomejs/cli-linux-arm64@2.4.12':
-    optional: true
+  '@biomejs/cli-linux-x64-musl@2.4.12': {}
 
-  '@biomejs/cli-linux-x64-musl@2.4.12':
-    optional: true
+  '@biomejs/cli-linux-x64@2.4.12': {}
 
-  '@biomejs/cli-linux-x64@2.4.12':
-    optional: true
+  '@biomejs/cli-win32-arm64@2.4.12': {}
 
-  '@biomejs/cli-win32-arm64@2.4.12':
-    optional: true
+  '@biomejs/cli-win32-x64@2.4.12': {}
 
-  '@biomejs/cli-win32-x64@2.4.12':
-    optional: true
-
-  '@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.8)':
+  '@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.10)':
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
-      postcss: 8.5.8
+      postcss: 8.5.10
       postcss-selector-parser: 7.1.1
 
   '@csstools/selector-resolve-nested@3.1.0(postcss-selector-parser@7.1.1)':
@@ -1345,25 +1352,9 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.1
 
-  '@emnapi/core@1.10.0':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.1
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@epic-web/invariant@1.0.0': {}
 
-  '@hono/node-server@1.19.13(hono@4.12.14)':
+  '@hono/node-server@1.19.14(hono@4.12.14)':
     dependencies:
       hono: 4.12.14
 
@@ -1378,19 +1369,19 @@ snapshots:
       xss: 1.0.15
 
   '@marp-team/marpit-svg-polyfill@2.1.0(@marp-team/marpit@3.2.1)':
-    optionalDependencies:
+    dependencies:
       '@marp-team/marpit': 3.2.1
 
   '@marp-team/marpit@3.2.1':
     dependencies:
-      '@csstools/postcss-is-pseudo-class': 5.0.3(postcss@8.5.8)
+      '@csstools/postcss-is-pseudo-class': 5.0.3(postcss@8.5.10)
       cssesc: 3.0.0
       js-yaml: 4.1.1
       lodash.kebabcase: 4.1.1
       markdown-it: 14.1.1
       markdown-it-front-matter: 0.2.4
-      postcss: 8.5.8
-      postcss-nesting: 13.0.2(postcss@8.5.8)
+      postcss: 8.5.10
+      postcss-nesting: 13.0.2(postcss@8.5.10)
 
   '@modelcontextprotocol/ext-apps@1.7.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(zod@4.3.6)':
     dependencies:
@@ -1400,16 +1391,16 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.13(hono@4.12.14)
+      '@hono/node-server': 1.19.14(hono@4.12.14)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       express: 5.2.1
-      express-rate-limit: 8.3.2(express@5.2.1)
+      express-rate-limit: 8.4.0(express@5.2.1)
       hono: 4.12.14
       jose: 6.2.2
       json-schema-typed: 8.0.2
@@ -1417,75 +1408,26 @@ snapshots:
       raw-body: 3.0.2
       zod: 4.3.6
       zod-to-json-schema: 3.25.2(zod@4.3.6)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
-    optional: true
 
   '@oxc-project/types@0.127.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    optional: true
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17': {}
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
-    optional: true
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17': {}
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    optional: true
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17': {}
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
-    optional: true
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17': {}
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    optional: true
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17': {}
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
-    optional: true
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17': {}
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optional: true
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
-    optional: true
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17': {}
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@standard-schema/spec@1.1.0': {}
-
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -1540,7 +1482,7 @@ snapshots:
       negotiator: 1.0.0
 
   ajv-formats@3.0.1(ajv@8.18.0):
-    optionalDependencies:
+    dependencies:
       ajv: 8.18.0
 
   ajv@8.18.0:
@@ -1558,6 +1500,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  async-function@1.0.0: {}
+
+  async-generator-function@1.0.0: {}
+
   body-parser@2.2.2:
     dependencies:
       bytes: 3.1.2
@@ -1566,11 +1512,9 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.1
       raw-body: 3.0.2
       type-is: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   braces@3.0.3:
     dependencies:
@@ -1586,7 +1530,7 @@ snapshots:
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
-      get-intrinsic: 1.3.0
+      get-intrinsic: 1.3.1
 
   chalk@4.1.2:
     dependencies:
@@ -1620,7 +1564,7 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 17.7.2
 
-  content-disposition@1.0.1: {}
+  content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
 
@@ -1686,13 +1630,13 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eventsource-parser@3.0.6: {}
+  eventsource-parser@3.0.8: {}
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
 
-  express-rate-limit@8.3.2(express@5.2.1):
+  express-rate-limit@8.4.0(express@5.2.1):
     dependencies:
       express: 5.2.1
       ip-address: 10.1.0
@@ -1701,7 +1645,7 @@ snapshots:
     dependencies:
       accepts: 2.0.0
       body-parser: 2.2.2
-      content-disposition: 1.0.1
+      content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
@@ -1719,7 +1663,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.1
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -1727,15 +1671,13 @@ snapshots:
       statuses: 2.0.2
       type-is: 2.0.1
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
   fast-uri@3.1.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
-    optionalDependencies:
+    dependencies:
       picomatch: 4.0.4
 
   fill-range@7.1.1:
@@ -1750,33 +1692,35 @@ snapshots:
       on-finished: 2.4.1
       parseurl: 1.3.3
       statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
 
-  fsevents@2.3.3:
-    optional: true
+  fsevents@2.3.3: {}
 
   function-bind@1.1.2: {}
+
+  generator-function@2.0.1: {}
 
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.5.0: {}
 
-  get-intrinsic@1.3.0:
+  get-intrinsic@1.3.1:
     dependencies:
+      async-function: 1.0.0
+      async-generator-function: 1.0.0
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       function-bind: 1.1.2
+      generator-function: 2.0.1
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       math-intrinsics: 1.1.0
 
   get-proto@1.0.1:
@@ -1790,7 +1734,7 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
-  hasown@2.0.2:
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -1838,48 +1782,25 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
-  lightningcss-android-arm64@1.32.0:
-    optional: true
+  lightningcss-darwin-arm64@1.32.0: {}
 
-  lightningcss-darwin-arm64@1.32.0:
-    optional: true
+  lightningcss-linux-arm64-gnu@1.32.0: {}
 
-  lightningcss-darwin-x64@1.32.0:
-    optional: true
+  lightningcss-linux-arm64-musl@1.32.0: {}
 
-  lightningcss-freebsd-x64@1.32.0:
-    optional: true
+  lightningcss-linux-x64-gnu@1.32.0: {}
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    optional: true
+  lightningcss-linux-x64-musl@1.32.0: {}
 
-  lightningcss-linux-arm64-gnu@1.32.0:
-    optional: true
+  lightningcss-win32-arm64-msvc@1.32.0: {}
 
-  lightningcss-linux-arm64-musl@1.32.0:
-    optional: true
-
-  lightningcss-linux-x64-gnu@1.32.0:
-    optional: true
-
-  lightningcss-linux-x64-musl@1.32.0:
-    optional: true
-
-  lightningcss-win32-arm64-msvc@1.32.0:
-    optional: true
-
-  lightningcss-win32-x64-msvc@1.32.0:
-    optional: true
+  lightningcss-win32-x64-msvc@1.32.0: {}
 
   lightningcss@1.32.0:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      lightningcss-android-arm64: 1.32.0
       lightningcss-darwin-arm64: 1.32.0
-      lightningcss-darwin-x64: 1.32.0
-      lightningcss-freebsd-x64: 1.32.0
-      lightningcss-linux-arm-gnueabihf: 1.32.0
       lightningcss-linux-arm64-gnu: 1.32.0
       lightningcss-linux-arm64-musl: 1.32.0
       lightningcss-linux-x64-gnu: 1.32.0
@@ -1911,7 +1832,7 @@ snapshots:
       esm: 3.2.25
       mhchemparser: 4.2.1
       mj-context-menu: 0.6.1
-      speech-rule-engine: 4.1.3
+      speech-rule-engine: 4.1.4
 
   mdurl@2.0.0: {}
 
@@ -1966,11 +1887,11 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  postcss-nesting@13.0.2(postcss@8.5.8):
+  postcss-nesting@13.0.2(postcss@8.5.10):
     dependencies:
       '@csstools/selector-resolve-nested': 3.1.0(postcss-selector-parser@7.1.1)
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
-      postcss: 8.5.8
+      postcss: 8.5.10
       postcss-selector-parser: 7.1.1
 
   postcss-selector-parser@7.1.1:
@@ -1984,12 +1905,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.8:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -1997,7 +1912,7 @@ snapshots:
 
   punycode.js@2.3.1: {}
 
-  qs@6.15.0:
+  qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
 
@@ -2019,19 +1934,11 @@ snapshots:
       '@oxc-project/types': 0.127.0
       '@rolldown/pluginutils': 1.0.0-rc.17
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.17
       '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
       '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
       '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
       '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
       '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
@@ -2042,8 +1949,6 @@ snapshots:
       is-promise: 4.0.0
       parseurl: 1.3.3
       path-to-regexp: 8.4.2
-    transitivePeerDependencies:
-      - supports-color
 
   rxjs@7.8.2:
     dependencies:
@@ -2064,8 +1969,6 @@ snapshots:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   serve-static@2.2.1:
     dependencies:
@@ -2073,8 +1976,6 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 1.2.1
-    transitivePeerDependencies:
-      - supports-color
 
   setprototypeof@1.2.0: {}
 
@@ -2086,7 +1987,7 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
-  side-channel-list@1.0.0:
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -2095,14 +1996,14 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       es-errors: 1.3.0
-      get-intrinsic: 1.3.0
+      get-intrinsic: 1.3.1
       object-inspect: 1.13.4
 
   side-channel-weakmap@1.0.2:
     dependencies:
       call-bound: 1.0.4
       es-errors: 1.3.0
-      get-intrinsic: 1.3.0
+      get-intrinsic: 1.3.1
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
@@ -2110,13 +2011,13 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-      side-channel-list: 1.0.0
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
   source-map-js@1.2.1: {}
 
-  speech-rule-engine@4.1.3:
+  speech-rule-engine@4.1.4:
     dependencies:
       '@xmldom/xmldom': 0.9.10
       commander: 13.1.0
@@ -2182,13 +2083,13 @@ snapshots:
 
   vite@8.0.10(@types/node@24.12.2):
     dependencies:
+      '@types/node': 24.12.2
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.10
       rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 24.12.2
       fsevents: 2.3.3
 
   which@2.0.2:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,1 @@
 minimumReleaseAge: 1440
-minimumReleaseAgeExclude:
-  - '@xmldom/xmldom@0.9.10'
-overrides:
-  '@xmldom/xmldom': 0.9.10


### PR DESCRIPTION
## Summary

- postcss XSS 脆弱性 (GHSA-qx2v-qp2m-jg93) 対応で `8.5.10` に override
- `pnpm-workspace.yaml` の `@xmldom/xmldom` override を `package.json` に移動し、overrides を一箇所に集約（`aube audit --fix` の出力先と統一）
- `@xmldom/xmldom@0.9.10` は公開から24時間経過済みのため `minimumReleaseAgeExclude` を削除

🤖 Generated with [Claude Code](https://claude.ai/code)