### PR TITLE
chore: overrides を pnpm.overrides キーに変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,10 @@
   "bin": {
     "marp-agent-mcp": "dist/index.js"
   },
-  "overrides": {
-    "@xmldom/xmldom": "0.9.10",
-    "postcss": "8.5.10"
+  "pnpm": {
+    "overrides": {
+      "@xmldom/xmldom": "0.9.10",
+      "postcss": "8.5.10"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Renovate は `pnpm-lock.yaml` を検出して pnpm でロックファイルを再生成するため、pnpm が読めない npm 流のトップレベル `overrides` だと再生成時に消えて整合性が崩れる（PR #167 で発覚）
- pnpm 公式の `pnpm.overrides` キーに移すことで pnpm（Renovate）も aube も読める形にする
- `aube audit --fix` は引き続きトップレベル `overrides` に書き出すが、同一ファイル内の重複として気付きやすく、手動で `pnpm.overrides` に移動する運用とする

🤖 Generated with [Claude Code](https://claude.ai/code)