### PR TITLE
chore: aube の install_before 上書きを解除

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -6,11 +6,8 @@ install_before = "1d"
 [tools]
 bun = "1.3.13"
 node = "24.15.0"
+"npm:@endevco/aube" = "1.0.0"
 "npm:@marp-team/marp-cli" = "4.3.1"
-
-[tools."npm:@endevco/aube"]
-version = "1.0.0"
-install_before = "0d"
 
 [task_config]
 includes = [


### PR DESCRIPTION
## Summary

- `[tools."npm:@endevco/aube"]` テーブルでの `install_before = "0d"` 上書きを解除し、通常の `[tools]` エントリに戻した
- `[settings]` の `install_before = "1d"` がそのまま適用される

🤖 Generated with [Claude Code](https://claude.com/claude-code)