### PR TITLE
chore: pnpm-override-prune を validate.sh に追加

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -9,6 +9,10 @@ node = "24.15.0"
 "npm:@endevco/aube" = "1.2.0"
 "npm:@marp-team/marp-cli" = "4.3.1"
 
+[tools."npm:pnpm-override-prune"]
+version = "0.0.2"
+install_before = "0d"
+
 [task_config]
 includes = [
   "git::https://github.com/iwamot/mise-tasks.git//.mise/tasks?ref=v1.1.0",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,6 @@
     "marp-agent-mcp": "dist/index.js"
   },
   "pnpm": {
-    "overrides": {
-      "@xmldom/xmldom": ">=0.9.10",
-      "postcss": ">=8.5.10"
-    }
+    "overrides": {}
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@xmldom/xmldom': '>=0.9.10'
-  postcss: '>=8.5.10'
-
 time:
   '@biomejs/biome@2.4.13': 2026-04-23T15:40:57.553Z
   '@biomejs/cli-darwin-arm64@2.4.13': 2026-04-23T15:41:08.668Z

--- a/validate.sh
+++ b/validate.sh
@@ -10,6 +10,7 @@ mise install
 aube install --frozen-lockfile
 aube licenses
 aube audit --fix --ignore-unfixable
+pnpm-override-prune --fix
 aube exec biome migrate --write
 aube run check:write
 aube run typecheck


### PR DESCRIPTION
## Summary

- `mise.toml` に `npm:pnpm-override-prune` を pin (0.0.2, `install_before = "0d"`)
- `validate.sh` の `aube audit` 直後に `pnpm-override-prune --fix` を呼ぶ
- 既存の `pnpm.overrides` 2件 (`@xmldom/xmldom`, `postcss`) は両方とも自然解決でカバーされていたので prune 済み (`pnpm-lock.yaml` の overrides メタデータも追従)
- `iwamot/uv-override-prune#21`・`iwamot/collmbo#170`・`iwamot/pnpm-override-prune#7` と同じパターン

🤖 Generated with [Claude Code](https://claude.com/claude-code)