### PR TITLE
chore: テストのカバレッジ計測を有効化

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,4 +11,7 @@ permissions:
 
 jobs:
   validate:
-    uses: iwamot/workflows/.github/workflows/validate.yml@d718704d344724f106df3152191d71859c0f3715 # v1.3.0
+    permissions:
+      contents: read
+      id-token: write
+    uses: iwamot/workflows/.github/workflows/validate-with-coverage.yml@d718704d344724f106df3152191d71859c0f3715 # v1.3.0

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ dist/
 node_modules/
 .pnpm-debug.log*
 
+# Coverage
+coverage/
+*.lcov
+
 # IDE
 .vscode/
 .idea/

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "check": "biome check",
     "check:write": "biome check --write",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.server.json --noEmit",
-    "test": "bun test"
+    "test": "bun test --coverage --coverage-reporter=lcov --coverage-reporter=text"
   },
   "dependencies": {
     "@marp-team/marp-core": "4.3.0",


### PR DESCRIPTION
## Summary

- `bun test` に `--coverage --coverage-reporter=lcov --coverage-reporter=text` を追加し、lcov とテキストサマリを出力
- 共有ワークフローを `validate.yml` から `validate-with-coverage.yml` に切り替え、Codecov へ OIDC でアップロード（job に `id-token: write` を付与）
- ローカルでカバレッジ生成物が `git diff --exit-code` に引っかからないよう `coverage/` と `*.lcov` を `.gitignore` に追加

pnpm-override-prune と同じ構成に揃えた変更。