### PR TITLE
chore: use shared shell-lint task

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -18,6 +18,7 @@ aube run test
 
 # Shared lint tasks
 mise run gha-lint
+mise run shell-lint
 mise run docker-lint
 
 # Check for uncommitted changes


### PR DESCRIPTION
## Summary

- Add `mise run shell-lint` to `validate.sh` (between `gha-lint` and `docker-lint`). The `task_config.includes` bump to `iwamot/mise-tasks@v1.5.0` already landed via #195, so no `mise.toml` change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)