### PR TITLE
chore: validate.sh で aube audit --fix update を使うよう変更

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -9,7 +9,7 @@ mise install
 # TypeScript
 aube install --frozen-lockfile
 aube licenses
-aube audit --fix --ignore-unfixable
+aube audit --fix update --ignore-unfixable
 pnpm-override-prune --fix
 biome migrate --write
 aube run check:write


### PR DESCRIPTION
## Summary

- aube 1.4.0 で pnpm 互換の `--fix=update` がサポートされた（[endevco/aube#363](https://github.com/endevco/aube/pull/363)）。
- `validate.sh` で従来の override 方式ではなく update 方式を使うよう変更。package.json overrides を増やさず、lockfile の更新で脆弱性に対応する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)