### PR TITLE
chore: 空の pnpm 設定ブロックを package.json から削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,5 @@
   },
   "bin": {
     "marp-agent-mcp": "dist/index.js"
-  },
-  "pnpm": {
-    "overrides": {}
   }
 }


### PR DESCRIPTION
## Summary

`package.json` の `pnpm.overrides` が空のまま残っていたため削除する。

pnpm v11 で `package.json` の `pnpm` フィールドは設定として読まれなくなる予定だが、aube はまだ追従していない。ただし空フィールドなので、aube の現在の挙動でも有無で違いはない。先取りの cleanup として実施。

実 override が必要になった場合は、aube の追従状況に応じて適切な置き場所（`pnpm-workspace.yaml` の `overrides:` 等）を選ぶ。