### PR TITLE
chore: biome を mise から外して npm devDep に移行

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "files": {
     "includes": [
       "main.ts",

--- a/mise.toml
+++ b/mise.toml
@@ -4,10 +4,6 @@ min_version = "2026.4.17"
 install_before = "1d"
 
 [tools]
-# aqua バックエンド (GitHub Releases) で取得。
-# npm だとネイティブ binary tarball (@biomejs/cli-* 約30MB) の fetch が
-# CI で失敗しやすいため。
-biome = "2.4.13"
 bun = "1.3.13"
 node = "24.15.0"
 "npm:@endevco/aube" = "1.5.1"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "zod": "4.4.1"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.4.13",
     "@types/bun": "1.3.13",
     "pnpm-override-prune": "0.0.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,14 @@ settings:
   excludeLinksFromLockfile: false
 
 time:
+  '@biomejs/biome@2.4.13': 2026-04-23T15:40:57.553Z
+  '@biomejs/cli-darwin-arm64@2.4.13': 2026-04-23T15:41:08.668Z
+  '@biomejs/cli-linux-arm64-musl@2.4.13': 2026-04-23T15:41:33.094Z
+  '@biomejs/cli-linux-arm64@2.4.13': 2026-04-23T15:41:26.398Z
+  '@biomejs/cli-linux-x64-musl@2.4.13': 2026-04-23T15:41:51.908Z
+  '@biomejs/cli-linux-x64@2.4.13': 2026-04-23T15:41:43.305Z
+  '@biomejs/cli-win32-arm64@2.4.13': 2026-04-23T15:42:00.706Z
+  '@biomejs/cli-win32-x64@2.4.13': 2026-04-23T15:42:10.153Z
   pnpm-override-prune@0.0.6: 2026-04-28T02:31:18.107Z
   semver@7.7.4: 2026-02-05T17:23:11.131Z
   yaml@2.8.3: 2026-03-21T10:37:06.001Z
@@ -62,6 +70,9 @@ importers:
         specifier: 4.4.1
         version: 4.4.1
     devDependencies:
+      '@biomejs/biome':
+        specifier: 2.4.13
+        version: 2.4.13
       '@types/bun':
         specifier: 1.3.13
         version: 1.3.13
@@ -70,6 +81,75 @@ importers:
         version: 0.0.6
 
 packages:
+
+  '@biomejs/biome@2.4.13':
+    resolution: {integrity: sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.13':
+    resolution: {integrity: sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - darwin
+    cpu:
+    - arm64
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13':
+    resolution: {integrity: sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
+
+  '@biomejs/cli-linux-arm64@2.4.13':
+    resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
+
+  '@biomejs/cli-linux-x64-musl@2.4.13':
+    resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
+
+  '@biomejs/cli-linux-x64@2.4.13':
+    resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
+
+  '@biomejs/cli-win32-arm64@2.4.13':
+    resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - win32
+    cpu:
+    - arm64
+
+  '@biomejs/cli-win32-x64@2.4.13':
+    resolution: {integrity: sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==}
+    engines: {node: '>=14.21.3'}
+    os:
+    - win32
+    cpu:
+    - x64
 
   '@csstools/postcss-is-pseudo-class@5.0.3':
     resolution: {integrity: sha512-jS/TY4SpG4gszAtIg7Qnf3AS2pjcUM5SzxpApOrlndMeGhIbaTzWBzzP/IApXoNWEW7OhcjkRT48jnAUIFXhAQ==}
@@ -1039,6 +1119,30 @@ packages:
     resolution: {integrity: sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q==}
 
 snapshots:
+
+  '@biomejs/biome@2.4.13':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.13
+      '@biomejs/cli-linux-arm64': 2.4.13
+      '@biomejs/cli-linux-arm64-musl': 2.4.13
+      '@biomejs/cli-linux-x64': 2.4.13
+      '@biomejs/cli-linux-x64-musl': 2.4.13
+      '@biomejs/cli-win32-arm64': 2.4.13
+      '@biomejs/cli-win32-x64': 2.4.13
+
+  '@biomejs/cli-darwin-arm64@2.4.13': {}
+
+  '@biomejs/cli-linux-arm64-musl@2.4.13': {}
+
+  '@biomejs/cli-linux-arm64@2.4.13': {}
+
+  '@biomejs/cli-linux-x64-musl@2.4.13': {}
+
+  '@biomejs/cli-linux-x64@2.4.13': {}
+
+  '@biomejs/cli-win32-arm64@2.4.13': {}
+
+  '@biomejs/cli-win32-x64@2.4.13': {}
 
   '@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.10)':
     dependencies:

--- a/validate.sh
+++ b/validate.sh
@@ -11,7 +11,6 @@ aube install --frozen-lockfile
 aube licenses
 aube audit --fix update --ignore-unfixable
 aube run prune
-biome migrate --write
 aube run check:write
 aube run typecheck
 aube run test


### PR DESCRIPTION
## Summary

Renovate が `biome.json` の `$schema` URL と `mise.toml` の biome を別 datasource で検知するため、片方だけ bump された PR の CI で `biome migrate --write` が `$schema` を binary バージョンに書き戻し、`git diff --exit-code` で落ちる構造的問題があった。

これを解消するため、biome のバージョン管理を **package.json 一本化**に変更する。

- `mise.toml` から biome を削除
- `@biomejs/biome` を devDep として追加（platform binary は optional dep）
- `biome.json` の `$schema` を `./node_modules/@biomejs/biome/configuration_schema.json` に変更
- 日常的に no-op になる `biome migrate --write` を `validate.sh` から削除（major bump 時だけ手動で叩く運用）

これで schema と binary が常に一致し、Renovate の biome PR は単一管理ポイントから生成されるようになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)