### PR TITLE
chore: bun を mise から外して npm dependencies に移行

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,10 @@ FROM public.ecr.aws/docker/library/node:24.15.0-trixie-slim@sha256:735dd688da64d
 
 WORKDIR /app
 
-# Install aube and bun
+# Install aube
 # renovate: datasource=npm depName=@endevco/aube
 ARG AUBE_VERSION=1.5.1
-# renovate: datasource=npm depName=bun
-ARG BUN_VERSION=1.3.13
-RUN npm install -g @endevco/aube@${AUBE_VERSION} bun@${BUN_VERSION}
+RUN npm install -g @endevco/aube@${AUBE_VERSION}
 
 # Install dependencies
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,6 @@ min_version = "2026.4.17"
 install_before = "1d"
 
 [tools]
-bun = "1.3.13"
 node = "24.15.0"
 "npm:@endevco/aube" = "1.5.1"
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/cors": "2.8.19",
     "@types/express": "5.0.6",
     "@types/node": "24.12.2",
+    "bun": "1.3.13",
     "concurrently": "9.2.1",
     "cors": "2.8.6",
     "cross-env": "10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,17 @@ time:
   '@biomejs/cli-linux-x64@2.4.13': 2026-04-23T15:41:43.305Z
   '@biomejs/cli-win32-arm64@2.4.13': 2026-04-23T15:42:00.706Z
   '@biomejs/cli-win32-x64@2.4.13': 2026-04-23T15:42:10.153Z
+  '@oven/bun-darwin-aarch64@1.3.13': 2026-04-20T08:10:00.949Z
+  '@oven/bun-linux-aarch64-musl@1.3.13': 2026-04-20T08:10:59.484Z
+  '@oven/bun-linux-aarch64@1.3.13': 2026-04-20T08:10:26.522Z
+  '@oven/bun-linux-x64-baseline@1.3.13': 2026-04-20T08:10:49.239Z
+  '@oven/bun-linux-x64-musl-baseline@1.3.13': 2026-04-20T08:11:20.328Z
+  '@oven/bun-linux-x64-musl@1.3.13': 2026-04-20T08:11:09.710Z
+  '@oven/bun-linux-x64@1.3.13': 2026-04-20T08:10:38.102Z
+  '@oven/bun-windows-aarch64@1.3.13': 2026-04-20T08:11:55.165Z
+  '@oven/bun-windows-x64-baseline@1.3.13': 2026-04-20T08:11:44.620Z
+  '@oven/bun-windows-x64@1.3.13': 2026-04-20T08:11:32.818Z
+  bun@1.3.13: 2026-04-20T08:11:56.794Z
   pnpm-override-prune@0.0.6: 2026-04-28T02:31:18.107Z
   semver@7.7.4: 2026-02-05T17:23:11.131Z
   yaml@2.8.3: 2026-03-21T10:37:06.001Z
@@ -39,6 +50,9 @@ importers:
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
+      bun:
+        specifier: 1.3.13
+        version: 1.3.13
       concurrently:
         specifier: 9.2.1
         version: 9.2.1
@@ -219,6 +233,76 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@oven/bun-darwin-aarch64@1.3.13':
+    resolution: {integrity: sha512-qAS6Hg8Q14ckfBuqJ2Zh7gBQSVSUHeibSq4OFqBTv6DzyJuxYlr0sdYQzmYmnbPxbqobekqUDTa/4XEaqRi7vg==}
+    os:
+    - darwin
+    cpu:
+    - arm64
+
+  '@oven/bun-linux-aarch64-musl@1.3.13':
+    resolution: {integrity: sha512-UV9EE18VE5aRhWtV2L6MTAGGn3slhJJ2OW/m+FJM15maHm0qf1V7TaZY0FovxhdQRvnklSiQ7Ntv0H5TUX4w0g==}
+    os:
+    - linux
+    cpu:
+    - arm64
+
+  '@oven/bun-linux-aarch64@1.3.13':
+    resolution: {integrity: sha512-NbLOJdr+RBFO1vFZ2YUFg4oVJ+2ua6zrwo4ZWRs0jKKcGJWtbY2wY5uz+i0PkwH6b9HYaYDgVTzE4ev06ncYZw==}
+    os:
+    - linux
+    cpu:
+    - arm64
+
+  '@oven/bun-linux-x64-baseline@1.3.13':
+    resolution: {integrity: sha512-fOi4ziKzgJG4UrrNd4AicBs6Fu9GY5xOqg+9tC76nuZNDAdSh6++kzab6TNi1Ck0Yzq6zIBIdGit6/0uSbBn8A==}
+    os:
+    - linux
+    cpu:
+    - x64
+
+  '@oven/bun-linux-x64-musl-baseline@1.3.13':
+    resolution: {integrity: sha512-fqBKuiiWLEu2dVkowZaXgKS98xfrvBqivdoxRtRP3eINcpI1dcelGbsOz+Xphn7tbGAuBiE1/0AelvvvdqS9rg==}
+    os:
+    - linux
+    cpu:
+    - x64
+
+  '@oven/bun-linux-x64-musl@1.3.13':
+    resolution: {integrity: sha512-+VHhE44kEjCXcTFHyc81zfTxL9+vzh9RqIh7gM1iWNhxpctD9kzntbUkP3UTFTwwNjoou1o8VRyxQafvc4OepA==}
+    os:
+    - linux
+    cpu:
+    - x64
+
+  '@oven/bun-linux-x64@1.3.13':
+    resolution: {integrity: sha512-UwttIUXoe9fS+40OcjoaRHgZw+HCPFqBVWEXkXqAJ3W7wA0XPZrWsoMAD9sGh3TaLqrwdiMo5xPogwpXhOtVXA==}
+    os:
+    - linux
+    cpu:
+    - x64
+
+  '@oven/bun-windows-aarch64@1.3.13':
+    resolution: {integrity: sha512-+EvdRWRCRg95Xea4M2lqSJFTjzQBTJDQTMlbG8bmwFkVTN16MdmSH7xhfxVQWUOyZBLEpIwuNFIlBBxVCwSUyQ==}
+    os:
+    - win32
+    cpu:
+    - arm64
+
+  '@oven/bun-windows-x64-baseline@1.3.13':
+    resolution: {integrity: sha512-6gy4hhQSjq/T/S9hC9m3NxY0RY+9Ww+XNlB+8koIMTsMSYEjk7Ho+hFHQz1Bn4W61Ub7Vykufg+jgDgPfa2GFA==}
+    os:
+    - win32
+    cpu:
+    - x64
+
+  '@oven/bun-windows-x64@1.3.13':
+    resolution: {integrity: sha512-vqDEFX63ZZQF3YstPSpPD+RxNm5AILPdUuuKpNwsj7ld4NjhdHUYkAmLXDtKNWt9JMRL10bop//W8faY/LV+RQ==}
+    os:
+    - win32
+    cpu:
+    - x64
+
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
@@ -376,6 +460,17 @@ packages:
 
   bun-types@1.3.13:
     resolution: {integrity: sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==}
+
+  bun@1.3.13:
+    resolution: {integrity: sha512-b9T4xZ8KqCHs4+TkHJv540LG1B8OD7noKu0Qaizusx3jFtMDHY6osNqgbaOlwW2B8RB2AKzz+sjzlGKIGxIjZw==}
+    os:
+    - darwin
+    - linux
+    - win32
+    cpu:
+    - arm64
+    - x64
+    hasBin: true
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1217,6 +1312,26 @@ snapshots:
     transitivePeerDependencies:
     - supports-color
 
+  '@oven/bun-darwin-aarch64@1.3.13': {}
+
+  '@oven/bun-linux-aarch64-musl@1.3.13': {}
+
+  '@oven/bun-linux-aarch64@1.3.13': {}
+
+  '@oven/bun-linux-x64-baseline@1.3.13': {}
+
+  '@oven/bun-linux-x64-musl-baseline@1.3.13': {}
+
+  '@oven/bun-linux-x64-musl@1.3.13': {}
+
+  '@oven/bun-linux-x64@1.3.13': {}
+
+  '@oven/bun-windows-aarch64@1.3.13': {}
+
+  '@oven/bun-windows-x64-baseline@1.3.13': {}
+
+  '@oven/bun-windows-x64@1.3.13': {}
+
   '@oxc-project/types@0.127.0': {}
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
@@ -1344,6 +1459,19 @@ snapshots:
   bun-types@1.3.13:
     dependencies:
       '@types/node': 24.12.2
+
+  bun@1.3.13:
+    optionalDependencies:
+      '@oven/bun-darwin-aarch64': 1.3.13
+      '@oven/bun-linux-aarch64': 1.3.13
+      '@oven/bun-linux-aarch64-musl': 1.3.13
+      '@oven/bun-linux-x64': 1.3.13
+      '@oven/bun-linux-x64-baseline': 1.3.13
+      '@oven/bun-linux-x64-musl': 1.3.13
+      '@oven/bun-linux-x64-musl-baseline': 1.3.13
+      '@oven/bun-windows-aarch64': 1.3.13
+      '@oven/bun-windows-x64': 1.3.13
+      '@oven/bun-windows-x64-baseline': 1.3.13
 
   bytes@3.1.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - pnpm-override-prune
+allowBuilds:
+  bun: true


### PR DESCRIPTION
## Summary

biome 移行と同じパターンで、bun のバージョン管理を package.json 一本化する。

bun は Docker Stage 1 の `aube run build` で必要なので、typescript や vite と同様に dependencies に置く（devDependencies だと `aube install --prod` で除外されてしまう）。

- `mise.toml` から bun を削除
- `package.json` の dependencies に bun を追加
- Dockerfile の `BUN_VERSION` ARG と `npm install -g bun` を削除
- `pnpm-workspace.yaml` の `allowBuilds` で bun の postinstall を許可（platform binary 配置のため）

bun の dual tracking が消滅し、Renovate は package.json 1 箇所で追従するようになる。

ローカルで `./validate.sh` と `docker build --target app-builder` を verify 済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)