### PR TITLE
chore: bun を mise に戻す

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,12 @@ FROM public.ecr.aws/docker/library/node:24.15.0-trixie-slim@sha256:735dd688da64d
 
 WORKDIR /app
 
-# Install aube
+# Install aube and bun
 # renovate: datasource=npm depName=@endevco/aube
 ARG AUBE_VERSION=1.5.1
-RUN npm install -g @endevco/aube@${AUBE_VERSION}
+# renovate: datasource=npm depName=bun
+ARG BUN_VERSION=1.3.13
+RUN npm install -g @endevco/aube@${AUBE_VERSION} bun@${BUN_VERSION}
 
 # Install dependencies
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./

--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,7 @@ install_before = "1d"
 
 [tools]
 biome = "2.4.13"
+bun = "1.3.13"
 node = "24.15.0"
 "npm:@endevco/aube" = "1.5.1"
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@types/cors": "2.8.19",
     "@types/express": "5.0.6",
     "@types/node": "24.12.2",
-    "bun": "1.3.13",
     "concurrently": "9.2.1",
     "cors": "2.8.6",
     "cross-env": "10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 time:
-  '@oven/bun-linux-x64-baseline@1.3.13': 2026-04-20T08:10:49.239Z
-  '@oven/bun-linux-x64-musl-baseline@1.3.13': 2026-04-20T08:11:20.328Z
-  '@oven/bun-linux-x64-musl@1.3.13': 2026-04-20T08:11:09.710Z
-  '@oven/bun-linux-x64@1.3.13': 2026-04-20T08:10:38.102Z
-  bun@1.3.13: 2026-04-20T08:11:56.794Z
   pnpm-override-prune@0.0.6: 2026-04-28T02:31:18.107Z
   semver@7.7.4: 2026-02-05T17:23:11.131Z
   yaml@2.8.3: 2026-03-21T10:37:06.001Z
@@ -36,9 +31,6 @@ importers:
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
-      bun:
-        specifier: 1.3.13
-        version: 1.3.13
       concurrently:
         specifier: 9.2.1
         version: 9.2.1
@@ -147,34 +139,6 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@oven/bun-linux-x64-baseline@1.3.13':
-    resolution: {integrity: sha512-fOi4ziKzgJG4UrrNd4AicBs6Fu9GY5xOqg+9tC76nuZNDAdSh6++kzab6TNi1Ck0Yzq6zIBIdGit6/0uSbBn8A==}
-    os:
-    - linux
-    cpu:
-    - x64
-
-  '@oven/bun-linux-x64-musl-baseline@1.3.13':
-    resolution: {integrity: sha512-fqBKuiiWLEu2dVkowZaXgKS98xfrvBqivdoxRtRP3eINcpI1dcelGbsOz+Xphn7tbGAuBiE1/0AelvvvdqS9rg==}
-    os:
-    - linux
-    cpu:
-    - x64
-
-  '@oven/bun-linux-x64-musl@1.3.13':
-    resolution: {integrity: sha512-+VHhE44kEjCXcTFHyc81zfTxL9+vzh9RqIh7gM1iWNhxpctD9kzntbUkP3UTFTwwNjoou1o8VRyxQafvc4OepA==}
-    os:
-    - linux
-    cpu:
-    - x64
-
-  '@oven/bun-linux-x64@1.3.13':
-    resolution: {integrity: sha512-UwttIUXoe9fS+40OcjoaRHgZw+HCPFqBVWEXkXqAJ3W7wA0XPZrWsoMAD9sGh3TaLqrwdiMo5xPogwpXhOtVXA==}
-    os:
-    - linux
-    cpu:
-    - x64
-
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
@@ -278,17 +242,6 @@ packages:
 
   bun-types@1.3.13:
     resolution: {integrity: sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==}
-
-  bun@1.3.13:
-    resolution: {integrity: sha512-b9T4xZ8KqCHs4+TkHJv540LG1B8OD7noKu0Qaizusx3jFtMDHY6osNqgbaOlwW2B8RB2AKzz+sjzlGKIGxIjZw==}
-    os:
-    - darwin
-    - linux
-    - win32
-    cpu:
-    - arm64
-    - x64
-    hasBin: true
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1046,14 +999,6 @@ snapshots:
     transitivePeerDependencies:
     - supports-color
 
-  '@oven/bun-linux-x64-baseline@1.3.13': {}
-
-  '@oven/bun-linux-x64-musl-baseline@1.3.13': {}
-
-  '@oven/bun-linux-x64-musl@1.3.13': {}
-
-  '@oven/bun-linux-x64@1.3.13': {}
-
   '@oxc-project/types@0.127.0': {}
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
@@ -1163,13 +1108,6 @@ snapshots:
   bun-types@1.3.13:
     dependencies:
       '@types/node': 24.12.2
-
-  bun@1.3.13:
-    optionalDependencies:
-      '@oven/bun-linux-x64': 1.3.13
-      '@oven/bun-linux-x64-baseline': 1.3.13
-      '@oven/bun-linux-x64-musl': 1.3.13
-      '@oven/bun-linux-x64-musl-baseline': 1.3.13
 
   bytes@3.1.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,3 @@
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - pnpm-override-prune
-allowBuilds:
-  bun: true


### PR DESCRIPTION
## Summary

[#211](https://github.com/iwamot/marp-agent-mcp/pull/211) を revert。bun も biome 同様、mise を真の source とする方針に揃える。

mise を選ぶ理由:

- aqua/GitHub Releases 経由は npm CDN より大型 binary の取得が安定（pnpm-override-prune の bun 移行 PR #34 で実際に CI flake が発生し、mise の方が信頼できることが裏付けられた）
- bun には Linux x64 だけで 4 つの platform variant (regular, baseline, musl, musl-baseline) が optional dep として存在し、npm 経由だと 200MB 弱の fetch surface を毎回さらすが、aqua 経由なら単一 binary 50MB で済む
- mise.toml が tool バージョンの単一 source

変更:
- `mise.toml` に `bun = "1.3.13"` を追加
- `dependencies` から `bun` を削除
- Dockerfile に `BUN_VERSION` ARG と `bun@${BUN_VERSION}` の `npm install -g` を復元
- `pnpm-workspace.yaml` の `allowBuilds.bun` を削除（bun が node_modules に居なくなるので不要）

ローカルで `./validate.sh` と `docker build --target app-builder` を verify 済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)