### PR TITLE
chore: pnpm-override-prune を mise に移す

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,7 @@ biome = "2.4.13"
 bun = "1.3.13"
 node = "24.15.0"
 "npm:@endevco/aube" = "1.5.1"
+"npm:pnpm-override-prune" = "0.0.6"
 
 [task_config]
 includes = [

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "zod": "4.4.1"
   },
   "devDependencies": {
-    "@types/bun": "1.3.13",
-    "pnpm-override-prune": "0.0.6"
+    "@types/bun": "1.3.13"
   },
   "types": "dist/server.d.ts",
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 time:
-  pnpm-override-prune@0.0.6: 2026-04-28T02:31:18.107Z
-  semver@7.7.4: 2026-02-05T17:23:11.131Z
   yaml@2.8.3: 2026-03-21T10:37:06.001Z
 
 importers:
@@ -65,9 +63,6 @@ importers:
       '@types/bun':
         specifier: 1.3.13
         version: 1.3.13
-      pnpm-override-prune:
-        specifier: 0.0.6
-        version: 0.0.6
 
 packages:
 
@@ -647,11 +642,6 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
-  pnpm-override-prune@0.0.6:
-    resolution: {integrity: sha512-5jX7W30POhH51rUFcgfDq1MPniQNIzvkCUe6Tski/VLt31rc0Vr74Sc6UqMx6NfG+TPz/nNF+0CiqhRGqON+Wg==}
-    engines: {node: '>=20'}
-    hasBin: true
-
   postcss-nesting@13.0.2:
     resolution: {integrity: sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==}
     engines: {node: '>=18'}
@@ -708,11 +698,6 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
@@ -1462,11 +1447,6 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  pnpm-override-prune@0.0.6:
-    dependencies:
-      semver: 7.7.4
-      yaml: 2.8.3
-
   postcss-nesting@13.0.2(postcss@8.5.10):
     dependencies:
       '@csstools/selector-resolve-nested': 3.1.0(postcss-selector-parser@7.1.1)
@@ -1531,8 +1511,6 @@ snapshots:
       tslib: 2.8.1
 
   safer-buffer@2.1.2: {}
-
-  semver@7.7.4: {}
 
   send@1.2.1:
     dependencies:


### PR DESCRIPTION
## Summary

mise primary 方針に従い、binary tool として独立して動く pnpm-override-prune は `package.json` devDep ではなく `mise.toml` で管理する。

`aube run prune` は package.json のスクリプト (`"prune": "pnpm-override-prune --fix"`) を実行するが、aube が `node_modules/.bin` と mise の shim PATH の両方を見るので、`node_modules` に居なくなった後も mise shim 経由で解決される（local `validate.sh` で動作確認済み）。

Dockerfile は `aube run prune` を呼ばないので影響なし。

変更:
- `mise.toml` に `npm:pnpm-override-prune = "0.0.6"` を追加
- `devDependencies` から `pnpm-override-prune` を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)