### PR TITLE
chore: marp-cli を mise.toml に追加

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -8,6 +8,7 @@ biome = "2.4.13"
 bun = "1.3.13"
 node = "24.15.0"
 "npm:@endevco/aube" = "1.5.1"
+"npm:@marp-team/marp-cli" = "4.3.1"
 "npm:pnpm-override-prune" = "0.0.6"
 
 [task_config]


### PR DESCRIPTION
## Summary

これまで marp-cli は Dockerfile ARG だけで管理していた（ローカル dev では使わないため）。本リポでは tool バージョンの単一 source を `mise.toml` に揃える方向で他のツール（biome, bun, aube, pnpm-override-prune）も整理してきており、marp-cli も同様に `mise.toml` に置く。

- `mise.toml` に `npm:@marp-team/marp-cli = "4.3.1"` を追加
- Dockerfile の `MARP_CLI_VERSION` ARG はそのまま（後続 PR で `mise.toml` から sed 抽出する形に同期する想定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)