### PR TITLE
chore: Renovate annotation を mise の検出値に揃えて重複 PR を解消する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ FROM public.ecr.aws/docker/library/node:24.15.0-trixie-slim@sha256:735dd688da64d
 WORKDIR /app
 
 # Install aube and bun
-# renovate: datasource=npm depName=@endevco/aube
+# renovate: datasource=npm depName=npm:@endevco/aube packageName=@endevco/aube
 ARG AUBE_VERSION=1.5.1
-# renovate: datasource=npm depName=bun
+# renovate: datasource=github-releases depName=bun packageName=oven-sh/bun versioning=semver-coerced extractVersion=^bun-v(?<version>\S+)
 ARG BUN_VERSION=1.3.13
 RUN npm install -g @endevco/aube@${AUBE_VERSION} bun@${BUN_VERSION}
 
@@ -33,7 +33,7 @@ RUN aube run build
 # ============================================
 FROM public.ecr.aws/docker/library/node:24.15.0-trixie-slim@sha256:735dd688da64d22ebd9dd374b3e7e5a874635668fd2a6ec20ca1f99264294086 AS marp-builder
 
-# renovate: datasource=npm depName=@marp-team/marp-cli
+# renovate: datasource=npm depName=npm:@marp-team/marp-cli packageName=@marp-team/marp-cli
 ARG MARP_CLI_VERSION=4.3.1
 RUN npm install -g @marp-team/marp-cli@${MARP_CLI_VERSION}
 


### PR DESCRIPTION
## Summary

mise manager と Dockerfile customManager (`customManagers:dockerfileVersions`) が同じパッケージを別 depName で検出していたため、aube / marp-cli / bun の更新ごとに mise.toml 用と Dockerfile 用で 2 つの PR が作られていた。

Dockerfile の renovate annotation の datasource / depName / packageName を mise manager の検出値と一致させ、Renovate が同一 dep として認識して両ファイルを同一 PR で同時更新するよう揃える。

- aube / marp-cli: depName に `npm:` prefix を付与し、packageName で実 npm パッケージ名を別途指定
- bun: mise core プラグインが github-releases (`oven-sh/bun`) を datasource として扱うため、Dockerfile も同じ datasource / packageName / versioning / extractVersion に揃える

## 検証

`npx renovate --platform=local` を実行して、aube が mise / Dockerfile 両方の検出から単一 branch (`renovate/npm-endevco-aube-1.x`) に統合されることを確認した。bun / marp-cli は現状アップデート保留がないため branch 生成までは観測できないが、抽出される dep 情報 (datasource / depName / packageName / versioning / extractVersion) が両 manager で完全一致することを確認している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)