### PR TITLE
chore: SECURITY.md からアドバイザリ URL 行を削除

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,5 +7,3 @@ This software is provided "as is" without warranty. Security issues will be addr
 ## Reporting a Vulnerability
 
 Please report security vulnerabilities through GitHub's Security Advisory "Report a Vulnerability" feature.
-
-https://github.com/iwamot/marp-agent-mcp/security/advisories/new


### PR DESCRIPTION
## Summary
- iwamot/repo-template の SECURITY.md と本文を完全に一致させるため、末尾のアドバイザリ URL を削除します。
- 報告フロー自体は GitHub の Security タブから到達できるので、案内としての実害はありません。