### PR TITLE
chore: ワークフロー最上位の permissions を {} に絞り、ジョブ単位で付与

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,10 +1,11 @@
 name: Dependabot auto-merge
 on: pull_request
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   dependabot-auto-merge:
+    permissions:
+      contents: write       # to merge auto-merge PRs
+      pull-requests: write  # to enable auto-merge
     uses: iwamot/workflows/.github/workflows/dependabot-auto-merge.yml@d1fbf4d009ef835741c9801626f014ef90a7dac2 # v1.4.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,10 +3,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   dependency-review:
+    permissions:
+      contents: read
+      pull-requests: write  # to comment review summary
     uses: iwamot/workflows/.github/workflows/dependency-review.yml@d1fbf4d009ef835741c9801626f014ef90a7dac2 # v1.4.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,15 +5,14 @@ on:
     tags:
       - "v*.*.*"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   publish:
     uses: iwamot/workflows/.github/workflows/publish-ecr-public.yml@d1fbf4d009ef835741c9801626f014ef90a7dac2 # v1.4.0
     permissions:
       contents: read
-      id-token: write
+      id-token: write  # to mint OIDC token for AWS role assumption
     with:
       registry_image: public.ecr.aws/k7d3h0b5/iwamot/marp-agent-mcp
     secrets:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -15,11 +15,12 @@ on:
           - info
           - debug
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   renovate:
+    permissions:
+      contents: read
     uses: iwamot/workflows/.github/workflows/renovate.yml@d1fbf4d009ef835741c9801626f014ef90a7dac2 # v1.4.0
     with:
       log-level: ${{ inputs.log-level || 'info' }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,12 +6,11 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   validate:
     permissions:
       contents: read
-      id-token: write
+      id-token: write  # for Codecov OIDC upload
     uses: iwamot/workflows/.github/workflows/validate-with-coverage.yml@d1fbf4d009ef835741c9801626f014ef90a7dac2 # v1.4.0


### PR DESCRIPTION
## Summary

- ワークフロー最上位の \`permissions\` を \`{}\` に変更し、各ジョブで必要最小限の権限のみを付与する。
- 書き込み権限には意図を示すコメントを併記する。
- zizmor の \`--pedantic\` audit (\`excessive-permissions\` / \`undocumented-permissions\`) による検出に対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)