### PR TITLE
fix(deps): ip-address の脆弱性を override で塞ぐ

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,216 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  ip-address: '>=10.1.1'
+
+time:
+  '@csstools/postcss-is-pseudo-class@5.0.3': 2025-06-11T10:37:31.892Z
+  '@csstools/selector-resolve-nested@3.1.0': 2025-06-06T09:57:24.889Z
+  '@csstools/selector-specificity@5.0.0': 2024-10-23T21:44:00.675Z
+  '@epic-web/invariant@1.0.0': 2023-12-14T00:28:05.418Z
+  '@hono/node-server@1.19.14': 2026-04-13T01:20:00.328Z
+  '@marp-team/marp-core@4.3.0': 2026-02-28T19:15:13.725Z
+  '@marp-team/marpit-svg-polyfill@2.1.0': 2023-02-10T10:56:19.299Z
+  '@marp-team/marpit@3.2.1': 2026-02-28T17:23:24.136Z
+  '@modelcontextprotocol/ext-apps@1.7.1': 2026-04-27T15:20:43.038Z
+  '@modelcontextprotocol/sdk@1.29.0': 2026-03-30T16:50:42.718Z
+  '@oxc-project/types@0.127.0': 2026-04-20T19:31:02.662Z
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17': 2026-04-22T11:13:47.749Z
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17': 2026-04-22T11:13:42.623Z
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17': 2026-04-22T11:13:53.598Z
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17': 2026-04-22T11:13:18.886Z
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17': 2026-04-22T11:13:25.244Z
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17': 2026-04-22T11:14:04.463Z
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17': 2026-04-22T11:13:13.128Z
+  '@rolldown/pluginutils@1.0.0-rc.17': 2026-04-22T11:13:01.300Z
+  '@standard-schema/spec@1.1.0': 2025-12-15T20:49:46.431Z
+  '@types/body-parser@1.19.6': 2025-06-07T02:15:26.399Z
+  '@types/bun@1.3.13': 2026-04-22T15:55:43.685Z
+  '@types/connect@3.4.38': 2023-11-07T00:57:34.681Z
+  '@types/cors@2.8.19': 2025-06-07T02:16:26.348Z
+  '@types/express-serve-static-core@5.1.1': 2026-01-10T09:35:12.712Z
+  '@types/express@5.0.6': 2025-12-01T20:35:51.488Z
+  '@types/http-errors@2.0.5': 2025-06-07T02:17:33.428Z
+  '@types/node@24.12.2': 2026-04-03T11:15:02.599Z
+  '@types/qs@6.15.0': 2026-03-06T02:55:59.542Z
+  '@types/range-parser@1.2.7': 2023-11-07T13:45:22.371Z
+  '@types/send@1.2.1': 2025-10-24T04:37:36.382Z
+  '@types/serve-static@2.2.0': 2025-10-27T20:36:09.811Z
+  '@xmldom/xmldom@0.9.10': 2026-04-18T11:34:10.031Z
+  accepts@2.0.0: 2024-08-31T15:50:05.694Z
+  ajv-formats@3.0.1: 2024-03-30T11:30:26.728Z
+  ajv@8.20.0: 2026-04-24T15:22:16.529Z
+  ansi-regex@5.0.1: 2021-09-14T15:55:19.540Z
+  ansi-styles@4.3.0: 2020-10-04T19:18:25.986Z
+  argparse@2.0.1: 2020-08-28T21:14:26.713Z
+  body-parser@2.2.2: 2026-01-07T09:38:34.589Z
+  braces@3.0.3: 2024-05-21T08:59:11.390Z
+  bun-types@1.3.13: 2026-04-20T08:09:49.687Z
+  bytes@3.1.2: 2022-01-28T05:02:37.661Z
+  call-bind-apply-helpers@1.0.2: 2025-02-12T19:24:56.950Z
+  call-bound@1.0.4: 2025-03-03T17:50:03.505Z
+  chalk@4.1.2: 2021-07-30T12:02:52.839Z
+  cliui@8.0.1: 2022-10-01T01:16:14.782Z
+  color-convert@2.0.1: 2019-08-19T21:05:36.605Z
+  color-name@1.1.4: 2018-09-21T10:48:56.546Z
+  commander@13.1.0: 2025-01-20T23:29:10.201Z
+  commander@2.20.3: 2019-10-11T05:40:24.166Z
+  commander@8.3.0: 2021-10-22T07:02:06.771Z
+  concurrently@9.2.1: 2025-08-25T09:50:49.138Z
+  content-disposition@1.1.0: 2026-04-07T21:07:53.748Z
+  content-type@1.0.5: 2023-01-29T19:25:59.622Z
+  cookie-signature@1.2.2: 2024-10-29T19:39:47.642Z
+  cookie@0.7.2: 2024-10-07T03:41:28.828Z
+  cors@2.8.6: 2026-01-22T14:41:30.223Z
+  cross-env@10.1.0: 2025-09-29T17:34:12.232Z
+  cross-spawn@7.0.6: 2024-11-18T13:59:52.129Z
+  cssesc@3.0.0: 2019-02-04T16:34:20.250Z
+  cssfilter@0.0.10: 2017-02-01T02:51:18.200Z
+  debug@4.4.3: 2025-09-13T17:25:19.732Z
+  depd@2.0.0: 2018-10-26T17:52:55.936Z
+  detect-libc@2.1.2: 2025-10-05T12:46:33.077Z
+  dunder-proto@1.0.1: 2024-12-17T02:12:47.047Z
+  ee-first@1.1.1: 2015-05-25T19:18:28.732Z
+  emoji-regex@8.0.0: 2019-03-05T18:58:23.040Z
+  encodeurl@2.0.0: 2024-03-29T00:03:42.135Z
+  entities@4.5.0: 2023-04-13T17:57:56.308Z
+  es-define-property@1.0.1: 2024-12-06T18:16:02.148Z
+  es-errors@1.3.0: 2024-02-05T08:05:51.479Z
+  es-object-atoms@1.1.1: 2025-01-15T00:42:43.342Z
+  escalade@3.2.0: 2024-08-29T22:59:36.690Z
+  escape-html@1.0.3: 2015-09-01T04:47:22.713Z
+  esm@3.2.25: 2019-05-17T05:24:41.368Z
+  etag@1.8.1: 2017-09-13T02:43:44.422Z
+  eventsource-parser@3.0.8: 2026-04-19T17:45:17.687Z
+  eventsource@3.0.7: 2025-05-09T10:32:51.243Z
+  express-rate-limit@8.5.0: 2026-05-04T21:49:59.771Z
+  express@5.2.1: 2025-12-01T20:49:43.268Z
+  fast-deep-equal@3.1.3: 2020-06-08T07:27:28.474Z
+  fast-uri@3.1.2: 2026-05-05T08:31:31.849Z
+  fdir@6.5.0: 2025-08-14T16:56:03.948Z
+  fill-range@7.1.1: 2024-05-21T08:45:51.224Z
+  finalhandler@2.1.1: 2025-12-01T16:05:02.140Z
+  forwarded@0.2.0: 2021-05-31T23:23:02.495Z
+  fresh@2.0.0: 2024-09-04T23:24:48.361Z
+  fsevents@2.3.3: 2023-08-21T16:24:22.854Z
+  function-bind@1.1.2: 2023-10-12T19:08:19.687Z
+  get-caller-file@2.0.5: 2019-03-09T21:48:30.527Z
+  get-east-asian-width@1.5.0: 2026-02-18T16:34:54.366Z
+  get-intrinsic@1.3.0: 2025-02-22T20:54:20.619Z
+  get-proto@1.0.1: 2025-01-02T20:08:02.949Z
+  gopd@1.2.0: 2024-12-04T16:21:52.727Z
+  has-flag@4.0.0: 2019-04-06T15:49:21.907Z
+  has-symbols@1.1.0: 2024-12-02T16:34:17.679Z
+  hasown@2.0.3: 2026-04-17T22:12:06.275Z
+  highlight.js@11.11.1: 2024-12-25T17:53:19.490Z
+  hono@4.12.18: 2026-05-06T11:32:30.638Z
+  http-errors@2.0.1: 2025-11-20T19:12:22.755Z
+  iconv-lite@0.7.2: 2026-01-08T16:49:11.167Z
+  inherits@2.0.4: 2019-06-19T20:18:52.465Z
+  ip-address@10.2.0: 2026-05-01T06:34:05.804Z
+  ipaddr.js@1.9.1: 2019-07-17T02:28:19.618Z
+  is-fullwidth-code-point@3.0.0: 2019-03-18T08:09:05.035Z
+  is-number@7.0.0: 2018-07-04T15:08:58.238Z
+  is-promise@4.0.0: 2020-04-27T15:34:23.345Z
+  isexe@2.0.0: 2017-03-23T00:53:16.356Z
+  jose@6.2.3: 2026-04-27T15:23:35.019Z
+  js-yaml@4.1.1: 2025-11-12T15:18:03.524Z
+  json-schema-traverse@1.0.0: 2020-12-13T10:56:54.719Z
+  json-schema-typed@8.0.2: 2025-11-17T20:30:24.942Z
+  katex@0.16.45: 2026-04-05T13:32:39.675Z
+  lightningcss-darwin-arm64@1.32.0: 2026-03-09T04:23:07.357Z
+  lightningcss-linux-arm64-gnu@1.32.0: 2026-03-09T04:23:18.594Z
+  lightningcss-linux-arm64-musl@1.32.0: 2026-03-09T04:23:21.203Z
+  lightningcss-linux-x64-gnu@1.32.0: 2026-03-09T04:23:24.274Z
+  lightningcss-linux-x64-musl@1.32.0: 2026-03-09T04:23:27.400Z
+  lightningcss-win32-arm64-msvc@1.32.0: 2026-03-09T04:23:30.176Z
+  lightningcss-win32-x64-msvc@1.32.0: 2026-03-09T04:23:33.073Z
+  lightningcss@1.32.0: 2026-03-09T04:23:43.754Z
+  linkify-it@5.0.0: 2023-12-01T21:47:27.805Z
+  lodash.kebabcase@4.1.1: 2016-08-13T17:41:29.425Z
+  markdown-it-front-matter@0.2.4: 2024-04-04T04:27:52.788Z
+  markdown-it@14.1.1: 2026-02-11T03:49:52.301Z
+  math-intrinsics@1.1.0: 2024-12-19T05:58:09.877Z
+  mathjax-full@3.2.2: 2022-06-08T17:29:04.841Z
+  mdurl@2.0.0: 2023-12-01T05:03:40.542Z
+  media-typer@1.1.0: 2019-04-25T03:16:05.379Z
+  merge-descriptors@2.0.0: 2023-11-16T18:49:20.714Z
+  mhchemparser@4.2.1: 2023-05-24T08:17:06.027Z
+  micromatch@4.0.8: 2024-08-23T16:31:18.748Z
+  mime-db@1.54.0: 2025-03-18T15:06:44.354Z
+  mime-types@3.0.2: 2025-11-20T11:12:29.693Z
+  mj-context-menu@0.6.1: 2020-08-20T10:50:52.317Z
+  ms@2.1.3: 2020-12-08T13:54:35.223Z
+  nanoid@3.3.12: 2026-04-30T22:04:14.515Z
+  negotiator@1.0.0: 2024-08-31T15:42:18.280Z
+  object-assign@4.1.1: 2017-01-16T15:35:15.282Z
+  object-inspect@1.13.4: 2025-02-05T01:26:10.272Z
+  on-finished@2.4.1: 2022-02-22T16:10:48.714Z
+  once@1.4.0: 2016-09-06T21:11:09.367Z
+  parseurl@1.3.3: 2019-04-16T04:16:26.547Z
+  path-key@3.1.1: 2019-11-22T16:47:18.153Z
+  path-to-regexp@8.4.2: 2026-04-01T21:17:05.201Z
+  picocolors@1.1.1: 2024-10-16T18:20:03.921Z
+  picomatch@2.3.2: 2026-03-23T20:39:08.118Z
+  picomatch@4.0.4: 2026-03-23T20:39:47.960Z
+  pkce-challenge@5.0.1: 2025-11-23T03:54:38.460Z
+  postcss-nesting@13.0.2: 2025-06-10T10:04:18.922Z
+  postcss-selector-parser@7.1.1: 2025-11-27T14:35:17.807Z
+  postcss@8.5.14: 2026-05-04T16:43:35.284Z
+  proxy-addr@2.0.7: 2021-06-01T00:57:28.507Z
+  punycode.js@2.3.1: 2023-10-30T18:28:36.491Z
+  qs@6.15.1: 2026-04-08T19:37:55.541Z
+  range-parser@1.2.1: 2019-05-11T00:27:37.805Z
+  raw-body@3.0.2: 2025-11-21T20:47:27.523Z
+  require-directory@2.1.1: 2015-05-28T08:31:04.702Z
+  require-from-string@2.0.2: 2018-04-09T09:49:47.301Z
+  rolldown@1.0.0-rc.17: 2026-04-22T11:14:29.632Z
+  router@2.2.0: 2025-03-27T00:38:18.615Z
+  rxjs@7.8.2: 2025-02-22T03:00:42.711Z
+  safer-buffer@2.1.2: 2018-04-08T10:42:42.130Z
+  send@1.2.1: 2025-12-15T19:36:11.862Z
+  serve-static@2.2.1: 2025-12-15T19:17:31.514Z
+  setprototypeof@1.2.0: 2019-07-18T04:49:56.614Z
+  shebang-command@2.0.0: 2019-09-06T14:53:25.901Z
+  shebang-regex@3.0.0: 2019-04-27T10:46:19.256Z
+  shell-quote@1.8.3: 2025-06-02T05:03:05.889Z
+  side-channel-list@1.0.1: 2026-04-08T16:55:13.603Z
+  side-channel-map@1.0.1: 2024-12-11T04:53:18.943Z
+  side-channel-weakmap@1.0.2: 2024-12-11T05:39:11.495Z
+  side-channel@1.1.0: 2024-12-11T17:00:33.553Z
+  source-map-js@1.2.1: 2024-09-08T16:22:55.645Z
+  speech-rule-engine@4.1.4: 2026-04-22T13:50:27.137Z
+  statuses@2.0.2: 2025-06-06T19:56:01.385Z
+  string-width@4.2.3: 2021-09-23T17:17:21.341Z
+  strip-ansi@6.0.1: 2021-09-23T16:34:41.798Z
+  supports-color@7.2.0: 2020-08-28T11:17:34.870Z
+  supports-color@8.1.1: 2021-01-23T09:21:36.393Z
+  tinyglobby@0.2.16: 2026-04-07T23:37:03.457Z
+  to-regex-range@5.0.1: 2019-04-07T06:04:37.030Z
+  toidentifier@1.0.1: 2021-11-14T22:19:09.631Z
+  tree-kill@1.2.2: 2019-12-11T18:34:21.876Z
+  tslib@2.8.1: 2024-10-31T22:42:48.624Z
+  type-is@2.0.1: 2025-03-27T01:20:01.576Z
+  typescript@6.0.3: 2026-04-16T23:38:27.905Z
+  uc.micro@2.1.0: 2024-03-02T17:44:53.816Z
+  undici-types@7.16.0: 2025-09-09T17:07:27.610Z
+  unpipe@1.0.0: 2015-06-14T20:30:19.934Z
+  util-deprecate@1.0.2: 2015-10-07T18:37:40.665Z
+  vary@1.1.2: 2017-09-24T01:47:11.325Z
+  vite-plugin-singlefile@2.3.3: 2026-04-17T22:28:03.802Z
+  vite@8.0.10: 2026-04-23T05:19:36.436Z
+  which@2.0.2: 2019-11-18T22:26:15.325Z
+  wicked-good-xpath@1.3.0: 2016-04-01T09:11:19.912Z
+  wrap-ansi@7.0.0: 2020-04-22T16:53:23.889Z
+  wrappy@1.0.2: 2016-05-17T23:30:52.415Z
+  xss@1.0.15: 2024-03-03T02:33:54.727Z
+  y18n@5.0.8: 2021-04-07T18:57:33.969Z
+  yargs-parser@21.1.1: 2022-08-04T21:13:43.411Z
+  yargs@17.7.2: 2023-04-27T19:59:02.861Z
+  zod-to-json-schema@3.25.2: 2026-03-27T07:09:39.645Z
+  zod@4.4.3: 2026-05-04T07:06:40.819Z
+
 importers:
 
   .:
@@ -46,10 +256,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 8.0.10
-        version: 8.0.10(@types/node@24.12.2)(yaml@2.8.3)
+        version: 8.0.10(@types/node@24.12.2)
       vite-plugin-singlefile:
         specifier: 2.3.3
-        version: 2.3.3(vite@8.0.10(@types/node@24.12.2)(yaml@2.8.3))
+        version: 2.3.3(vite@8.0.10(@types/node@24.12.2))
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -77,15 +287,6 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       postcss-selector-parser: ^7.0.0
-
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
-
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
-
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
@@ -136,119 +337,80 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
-
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
+      zod: {}
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
-    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
+    os:
+    - darwin
+    cpu:
+    - arm64
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
-    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - arm64
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - x64
 
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -315,14 +477,6 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-
-  async-function@1.0.0:
-    resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
-    engines: {node: '>= 0.4'}
-
-  async-generator-function@1.0.0:
-    resolution: {integrity: sha512-+NAXNqgCrB95ya4Sr66i1CL2hqLVckAk7xwRYWdcm39/ELQ6YNn1aw5r0bdQtqNZgQpEWzc5yc/igXc7aL5SLA==}
-    engines: {node: '>= 0.4'}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -418,8 +572,6 @@ packages:
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
     peerDependenciesMeta:
       supports-color:
         optional: true
@@ -485,8 +637,8 @@ packages:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
 
-  express-rate-limit@8.4.1:
-    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+  express-rate-limit@8.5.0:
+    resolution: {integrity: sha512-XKhFohWaSBdVJNTi5TaHziqnPkv04I9UQV6q1Wy7Ui6GGQZVW12ojDFwqer14EvCXxjvPG0CyWXx7cAXpALB4Q==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -498,8 +650,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -529,14 +681,11 @@ packages:
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
+    os:
+    - darwin
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  generator-function@2.0.1:
-    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
-    engines: {node: '>= 0.4'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -546,8 +695,8 @@ packages:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
 
-  get-intrinsic@1.3.1:
-    resolution: {integrity: sha512-fk1ZVEeOX9hVZ6QzoBNEC55+Ucqg4sTVwrVuigZhuRPESVFpMyXnd3sbXvPOwp7Y9riVyANiqhEuRF0G1aVSeQ==}
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
   get-proto@1.0.1:
@@ -574,8 +723,8 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
-  hono@4.12.15:
-    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -589,8 +738,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -611,8 +760,8 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  jose@6.2.2:
-    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
@@ -628,75 +777,69 @@ packages:
     resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
     hasBin: true
 
-  lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [android]
-
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm]
-    os: [linux]
+    os:
+    - darwin
+    cpu:
+    - arm64
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - glibc
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
+    os:
+    - linux
+    cpu:
+    - arm64
+    libc:
+    - musl
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - glibc
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
+    os:
+    - linux
+    cpu:
+    - x64
+    libc:
+    - musl
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - arm64
 
   lightningcss-win32-x64-msvc@1.32.0:
     resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
     engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [win32]
+    os:
+    - win32
+    cpu:
+    - x64
 
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
@@ -721,7 +864,6 @@ packages:
 
   mathjax-full@3.2.2:
     resolution: {integrity: sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==}
-    deprecated: Version 4 replaces this package with the scoped package @mathjax/src
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -755,8 +897,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -815,8 +957,8 @@ packages:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   proxy-addr@2.0.7:
@@ -1051,11 +1193,6 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -1074,10 +1211,10 @@ packages:
 
 snapshots:
 
-  '@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.10)':
+  '@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.14)':
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   '@csstools/selector-resolve-nested@3.1.0(postcss-selector-parser@7.1.1)':
@@ -1088,27 +1225,11 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.1
 
-  '@emnapi/core@1.10.0':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.1
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.10.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@epic-web/invariant@1.0.0': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.15)':
+  '@hono/node-server@1.19.14(hono@4.12.18)':
     dependencies:
-      hono: 4.12.15
+      hono: 4.12.18
 
   '@marp-team/marp-core@4.3.0':
     dependencies:
@@ -1121,19 +1242,19 @@ snapshots:
       xss: 1.0.15
 
   '@marp-team/marpit-svg-polyfill@2.1.0(@marp-team/marpit@3.2.1)':
-    optionalDependencies:
+    dependencies:
       '@marp-team/marpit': 3.2.1
 
   '@marp-team/marpit@3.2.1':
     dependencies:
-      '@csstools/postcss-is-pseudo-class': 5.0.3(postcss@8.5.10)
+      '@csstools/postcss-is-pseudo-class': 5.0.3(postcss@8.5.14)
       cssesc: 3.0.0
       js-yaml: 4.1.1
       lodash.kebabcase: 4.1.1
       markdown-it: 14.1.1
       markdown-it-front-matter: 0.2.4
-      postcss: 8.5.10
-      postcss-nesting: 13.0.2(postcss@8.5.10)
+      postcss: 8.5.14
+      postcss-nesting: 13.0.2(postcss@8.5.14)
 
   '@modelcontextprotocol/ext-apps@1.7.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
     dependencies:
@@ -1143,7 +1264,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.15)
+      '@hono/node-server': 1.19.14(hono@4.12.18)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -1152,83 +1273,34 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.8
       express: 5.2.1
-      express-rate-limit: 8.4.1(express@5.2.1)
-      hono: 4.12.15
-      jose: 6.2.2
+      express-rate-limit: 8.5.0(express@5.2.1)
+      hono: 4.12.18
+      jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 4.4.3
       zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
-    optional: true
 
   '@oxc-project/types@0.127.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.17':
-    optional: true
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17': {}
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
-    optional: true
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17': {}
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
-    optional: true
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17': {}
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
-    optional: true
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17': {}
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
-    optional: true
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17': {}
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
-    optional: true
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17': {}
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    optional: true
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
-    optional: true
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17': {}
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@standard-schema/spec@1.1.0': {}
-
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -1287,13 +1359,13 @@ snapshots:
       negotiator: 1.0.0
 
   ajv-formats@3.0.1(ajv@8.20.0):
-    optionalDependencies:
+    dependencies:
       ajv: 8.20.0
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1304,10 +1376,6 @@ snapshots:
       color-convert: 2.0.1
 
   argparse@2.0.1: {}
-
-  async-function@1.0.0: {}
-
-  async-generator-function@1.0.0: {}
 
   body-parser@2.2.2:
     dependencies:
@@ -1320,8 +1388,6 @@ snapshots:
       qs: 6.15.1
       raw-body: 3.0.2
       type-is: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   braces@3.0.3:
     dependencies:
@@ -1341,7 +1407,7 @@ snapshots:
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
-      get-intrinsic: 1.3.1
+      get-intrinsic: 1.3.0
 
   chalk@4.1.2:
     dependencies:
@@ -1447,10 +1513,10 @@ snapshots:
     dependencies:
       eventsource-parser: 3.0.8
 
-  express-rate-limit@8.4.1(express@5.2.1):
+  express-rate-limit@8.5.0(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -1482,15 +1548,13 @@ snapshots:
       statuses: 2.0.2
       type-is: 2.0.1
       vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
-    optionalDependencies:
+    dependencies:
       picomatch: 4.0.4
 
   fill-range@7.1.1:
@@ -1505,34 +1569,26 @@ snapshots:
       on-finished: 2.4.1
       parseurl: 1.3.3
       statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   forwarded@0.2.0: {}
 
   fresh@2.0.0: {}
 
-  fsevents@2.3.3:
-    optional: true
+  fsevents@2.3.3: {}
 
   function-bind@1.1.2: {}
-
-  generator-function@2.0.1: {}
 
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.5.0: {}
 
-  get-intrinsic@1.3.1:
+  get-intrinsic@1.3.0:
     dependencies:
-      async-function: 1.0.0
-      async-generator-function: 1.0.0
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       function-bind: 1.1.2
-      generator-function: 2.0.1
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
@@ -1556,7 +1612,7 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  hono@4.12.15: {}
+  hono@4.12.18: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -1572,7 +1628,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -1584,7 +1640,7 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  jose@6.2.2: {}
+  jose@6.2.3: {}
 
   js-yaml@4.1.1:
     dependencies:
@@ -1598,48 +1654,25 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
-  lightningcss-android-arm64@1.32.0:
-    optional: true
+  lightningcss-darwin-arm64@1.32.0: {}
 
-  lightningcss-darwin-arm64@1.32.0:
-    optional: true
+  lightningcss-linux-arm64-gnu@1.32.0: {}
 
-  lightningcss-darwin-x64@1.32.0:
-    optional: true
+  lightningcss-linux-arm64-musl@1.32.0: {}
 
-  lightningcss-freebsd-x64@1.32.0:
-    optional: true
+  lightningcss-linux-x64-gnu@1.32.0: {}
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    optional: true
+  lightningcss-linux-x64-musl@1.32.0: {}
 
-  lightningcss-linux-arm64-gnu@1.32.0:
-    optional: true
+  lightningcss-win32-arm64-msvc@1.32.0: {}
 
-  lightningcss-linux-arm64-musl@1.32.0:
-    optional: true
-
-  lightningcss-linux-x64-gnu@1.32.0:
-    optional: true
-
-  lightningcss-linux-x64-musl@1.32.0:
-    optional: true
-
-  lightningcss-win32-arm64-msvc@1.32.0:
-    optional: true
-
-  lightningcss-win32-x64-msvc@1.32.0:
-    optional: true
+  lightningcss-win32-x64-msvc@1.32.0: {}
 
   lightningcss@1.32.0:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      lightningcss-android-arm64: 1.32.0
       lightningcss-darwin-arm64: 1.32.0
-      lightningcss-darwin-x64: 1.32.0
-      lightningcss-freebsd-x64: 1.32.0
-      lightningcss-linux-arm-gnueabihf: 1.32.0
       lightningcss-linux-arm64-gnu: 1.32.0
       lightningcss-linux-arm64-musl: 1.32.0
       lightningcss-linux-x64-gnu: 1.32.0
@@ -1696,7 +1729,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   negotiator@1.0.0: {}
 
@@ -1726,11 +1759,11 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  postcss-nesting@13.0.2(postcss@8.5.10):
+  postcss-nesting@13.0.2(postcss@8.5.14):
     dependencies:
       '@csstools/selector-resolve-nested': 3.1.0(postcss-selector-parser@7.1.1)
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
-      postcss: 8.5.10
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
   postcss-selector-parser@7.1.1:
@@ -1738,9 +1771,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.10:
+  postcss@8.5.14:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -1773,19 +1806,11 @@ snapshots:
       '@oxc-project/types': 0.127.0
       '@rolldown/pluginutils': 1.0.0-rc.17
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.17
       '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
       '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
       '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
       '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
       '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
@@ -1796,8 +1821,6 @@ snapshots:
       is-promise: 4.0.0
       parseurl: 1.3.3
       path-to-regexp: 8.4.2
-    transitivePeerDependencies:
-      - supports-color
 
   rxjs@7.8.2:
     dependencies:
@@ -1818,8 +1841,6 @@ snapshots:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
 
   serve-static@2.2.1:
     dependencies:
@@ -1827,8 +1848,6 @@ snapshots:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 1.2.1
-    transitivePeerDependencies:
-      - supports-color
 
   setprototypeof@1.2.0: {}
 
@@ -1849,14 +1868,14 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       es-errors: 1.3.0
-      get-intrinsic: 1.3.1
+      get-intrinsic: 1.3.0
       object-inspect: 1.13.4
 
   side-channel-weakmap@1.0.2:
     dependencies:
       call-bound: 1.0.4
       es-errors: 1.3.0
-      get-intrinsic: 1.3.1
+      get-intrinsic: 1.3.0
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
@@ -1929,22 +1948,21 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-plugin-singlefile@2.3.3(vite@8.0.10(@types/node@24.12.2)(yaml@2.8.3)):
+  vite-plugin-singlefile@2.3.3(vite@8.0.10(@types/node@24.12.2)):
     dependencies:
       micromatch: 4.0.8
-      vite: 8.0.10(@types/node@24.12.2)(yaml@2.8.3)
+      vite: 8.0.10(@types/node@24.12.2)
 
-  vite@8.0.10(@types/node@24.12.2)(yaml@2.8.3):
+  vite@8.0.10(@types/node@24.12.2):
     dependencies:
+      '@types/node': 24.12.2
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.10
+      postcss: 8.5.14
       rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 24.12.2
       fsevents: 2.3.3
-      yaml: 2.8.3
 
   which@2.0.2:
     dependencies:
@@ -1967,9 +1985,6 @@ snapshots:
 
   y18n@5.0.8: {}
 
-  yaml@2.8.3:
-    optional: true
-
   yargs-parser@21.1.1: {}
 
   yargs@17.7.2:
@@ -1987,5 +2002,3 @@ snapshots:
       zod: 4.4.3
 
   zod@4.4.3: {}
-
-time: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - pnpm-override-prune
+overrides:
+  ip-address: ">=10.1.1"


### PR DESCRIPTION
## Summary

`pnpm-workspace.yaml` の `overrides` に `ip-address: ">=10.1.1"` を追加し、GHSA-v2v4-37r5-5v8g (XSS in Address6 HTML-emitting methods) を塞ぐ。`@modelcontextprotocol/sdk` → `express-rate-limit` 経由の transitive 依存。

hono の advisory (GHSA-9vqf-7f2p-gf9v / GHSA-69xw-7hcm-h432) も同時に override を当てたが、lockfile 再生成で transitive が 4.12.16+ に追従済みだったため `pnpm-override-prune` が冗長と判定して削除した。

`aube audit` で「No known vulnerabilities found」を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)