### PR TITLE
chore: add auto-label caller workflow

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,12 @@
+name: 'Auto label by title'
+on:
+  pull_request:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  label:
+    permissions:
+      pull-requests: write  # to add a label to the PR
+    uses: iwamot/workflows/.github/workflows/auto-label.yml@afdf21101495a5ec5df69338e8f94ed6ee8cf32d # v3.4.0


### PR DESCRIPTION
## Summary

Wires up [`iwamot/workflows`](https://github.com/iwamot/workflows/blob/v3.4.0/.github/workflows/auto-label.yml)' auto-label reusable. The reusable applies a release-note label based on the PR title's Conventional Commits prefix:

- `feat` → `feature`
- `fix` → `bugfix`
- `chore` / `docs` → `maintenance`
- anything else / no prefix → no label (surfaces in ❓ Uncategorized at release time)

## Skip behavior

Handled inside the reusable:

- Fork PRs (`if: !head.repo.fork`) — fork PRs run with read-only `GITHUB_TOKEN`, so attempting to label would 403; skipped cleanly.
- PRs already carrying any of `feature` / `bugfix` / `dependencies` / `maintenance` — covers Renovate (self-labels `dependencies`) and Oide (self-labels `maintenance`).

## Notes

Distributed manually via per-repo PRs (not via Oide). Workflow files stay per-repo so future customization is possible.