### PR TITLE
chore: prune unused .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,36 +3,15 @@ dist/
 
 # Dependencies
 node_modules/
-.pnpm-debug.log*
 
 # Coverage
 coverage/
-*.lcov
-
-# IDE
-.vscode/
-.idea/
-*.swp
-*.swo
-*~
 
 # Claude Code
 .claude/
 
-# OS
-.DS_Store
-Thumbs.db
-
-# Environment
-.env
-.env.local
-.env.*.local
-
 # Logs
 *.log
-logs/
 
 # Temporary files
 *.tmp
-*.temp
-.cache/


### PR DESCRIPTION
## Summary

working tree のどのファイル/ディレクトリにもマッチしない defensive pattern を削除した。

**削除したエントリ**
- IDE 設定: `.vscode/`, `.idea/`
- 編集者 swap: `*.swp`, `*.swo`, `*~`
- OS artifact: `.DS_Store`, `Thumbs.db`
- 防御的な env: `.env`, `.env.local`, `.env.*.local`
- その他: `*.lcov`, `.pnpm-debug.log*`, `logs/`, `*.temp`, `.cache/`

**整理**
- 空になったセクションヘッダーコメント (`# IDE`, `# OS`, `# Environment`) を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)