### PR TITLE
chore: exempt pnpm-override-prune from mise install_before gate

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -9,7 +9,10 @@ bun = "1.3.13"
 node = "24.15.0"
 "npm:@endevco/aube" = "1.9.1"
 "npm:@marp-team/marp-cli" = "4.4.0"
-"npm:pnpm-override-prune" = "0.0.6"
+
+[tools."npm:pnpm-override-prune"]
+version = "0.0.6"
+install_before = "0d"
 
 [task_config]
 includes = [


### PR DESCRIPTION
## Summary

- Renovate 共通設定 (iwamot/renovate-config) で `iwamot/**` は `minimumReleaseAge: null` となり、リリース直後に PR が立つ。一方 mise の `install_before = "1d"` が後段で当該 version を弾き、pnpm-override-prune 0.0.7 を上げる Renovate PR で CI が fail していた。
- per-tool 上書きで `[tools."npm:pnpm-override-prune"]` を切り出し `install_before = "0d"` を付与し、Renovate 側の方針と整合させる。
- 失敗した CI run: https://github.com/iwamot/marp-agent-mcp/actions/runs/25670257720/job/75353333761?pr=257