### PR TITLE
chore: introduce harden-runner in audit mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,16 @@ jobs:
     permissions:
       contents: write  # to create the draft GitHub Release
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
       - uses: iwamot/actions/release-draft@35af46540ea16f3adb318c1a1739572b61f6fc53 # v0.8.0
 
   publish:
     needs: release-draft
-    uses: iwamot/workflows/.github/workflows/publish-ecr-public.yml@ae5512be479f765d6f3f89302516a6f5c0add845 # v4.1.3
+    uses: iwamot/workflows/.github/workflows/publish-ecr-public.yml@15e638a17daad208034700f2429ee13db2452ce4 # v4.2.0
     permissions:
       contents: read
       id-token: write  # to mint OIDC token for AWS role assumption
@@ -40,4 +45,9 @@ jobs:
     permissions:
       contents: write  # to flip the draft GitHub Release to published
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
       - uses: iwamot/actions/release-publish@35af46540ea16f3adb318c1a1739572b61f6fc53 # v0.8.0


### PR DESCRIPTION
## 概要

- `release.yml` 内のステップを持つ全ジョブ (`release-draft`, `release-publish`) の先頭に `step-security/harden-runner` を追加し、`egress-policy: audit` で動かす。
- `iwamot/workflows/publish-ecr-public.yml` を v4.1.1 から v4.2.0 に bump し、`publish` / `merge-and-sign` ジョブ側にも harden-runner を行き渡らせる。
- audit モードは送信トラフィックをブロックせずに記録するだけなので挙動は変わらない。蓄積されたランタイムデータを基に、後日 `block` モードへ切り替える際の許可エンドポイントを決められる。