### PR TITLE
chore: oide.yml を workflows v6 + OIDE_APP_* secret に切り替え

### DIFF
--- a/.github/workflows/oide.yml
+++ b/.github/workflows/oide.yml
@@ -13,10 +13,10 @@ jobs:
   pull:
     permissions:
       contents: read
-    uses: iwamot/workflows/.github/workflows/oide.yml@ebf1be0e9a042e490eef4062613562225d4d206f # v5.0.0
+    uses: iwamot/workflows/.github/workflows/oide.yml@2999ae87b709bd1b1bb9ab110aa3055828848898 # v6.0.0
     with:
       # renovate: datasource=github-tags depName=iwamot/repo-template
       TEMPLATE_VERSION: v1.5.0
     secrets:
-      RENOVATE_APP_ID: ${{ secrets.RENOVATE_APP_ID }}
-      RENOVATE_PRIVATE_KEY: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+      OIDE_APP_CLIENT_ID: ${{ secrets.OIDE_APP_CLIENT_ID }}
+      OIDE_APP_PRIVATE_KEY: ${{ secrets.OIDE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Oide reusable workflow の pin を v6 に上げ、caller 側の secret pass-through を `OIDE_APP_CLIENT_ID` / `OIDE_APP_PRIVATE_KEY` に rename。これまで借用していた Renovate App credential を専用 iwamot-oide App に置き換える。