### PR TITLE
chore: release.yml を release-ecr-public.yml に移行

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,47 +7,13 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
-
 jobs:
-  release-draft:
-    name: release-draft
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
+  release:
+    uses: iwamot/workflows/.github/workflows/release-ecr-public.yml@d21b0a8606441bf9ace76ad014a80a9165de3a36 # v6.2.0
     permissions:
-      contents: write  # to create the draft GitHub Release
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
-      - uses: iwamot/actions/release-draft@09a90ef28919b6331a2930f6e61eeca11bc634de # v0.9.0
-
-  publish:
-    needs: release-draft
-    uses: iwamot/workflows/.github/workflows/publish-ecr-public.yml@cdc42cf2f91fd796de35bdc27aaaa1057695afcc # v6.1.0
-    permissions:
-      contents: read
-      id-token: write  # to mint OIDC token for AWS role assumption
+      contents: write  # to draft and publish the GitHub Release
+      id-token: write  # to mint OIDC token for AWS role assumption and cosign signing
     with:
       registry_image: public.ecr.aws/k7d3h0b5/iwamot/marp-agent-mcp
     secrets:
       aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
-
-  release-publish:
-    needs: publish
-    name: release-publish
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    permissions:
-      contents: write  # to flip the draft GitHub Release to published
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
-      - uses: iwamot/actions/release-publish@09a90ef28919b6331a2930f6e61eeca11bc634de # v0.9.0


### PR DESCRIPTION
## Summary

draft → publish-ecr-public → publish-flip の 3 ジョブ構成を、`iwamot/workflows/.github/workflows/release-ecr-public.yml@v6.2.0` への `uses:` 1 ジョブ呼び出しに置き換え。draft/publish の GitHub Release ブックエンドと `concurrency` ブロックは reusable workflow 側に内包される。

リリース成果物に変化なし。