### PR TITLE
chore: remove DCO app config and Oide entry

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,2 +1,0 @@
-allowRemediationCommits:
-  individual: true

--- a/Oidefile
+++ b/Oidefile
@@ -1,4 +1,3 @@
-.github/dco.yml
 .github/release.yml
 CONTRIBUTING.md
 Oidefile


### PR DESCRIPTION
## Summary

- DCO GitHub App は uninstall 済みで、代わりに `iwamot/workflows/.github/workflows/dco.yml` の reusable workflow が DCO check を実行する。
- `.github/dco.yml` (app の config) と `Oidefile` から対応するエントリを削除する。