### PR TITLE
chore: pull_request トリガーを main 宛 PR に限定

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -2,6 +2,7 @@ name: 'Auto label by title'
 on:
   pull_request:
     types: [opened]
+    branches: [ "main" ]
 
 permissions: {}
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [ "main" ]
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## 概要

`auto-label.yml` と `validate.yml` の `pull_request:` トリガーに `branches: [ "main" ]` を明示し、main を base とする PR のときだけ発火するようにする。`dco.yml` / `dependency-review.yml` は既に同じ制限が入っている。