### PR TITLE
chore: iwamot/workflows を v8.0.0 にバンプして attestation 用 permission を付与

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -10,4 +10,4 @@ jobs:
   label:
     permissions:
       pull-requests: write  # to add a label to the PR
-    uses: iwamot/workflows/.github/workflows/auto-label.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/auto-label.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -9,4 +9,4 @@ jobs:
   dco:
     permissions:
       pull-requests: read  # to read PR commits for DCO sign-off check
-    uses: iwamot/workflows/.github/workflows/dco.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/dco.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,4 +8,4 @@ jobs:
     permissions:
       contents: write       # to merge auto-merge PRs
       pull-requests: write  # to enable auto-merge
-    uses: iwamot/workflows/.github/workflows/dependabot-auto-merge.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/dependabot-auto-merge.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,4 +10,4 @@ jobs:
     permissions:
       contents: read
       pull-requests: write  # to comment review summary
-    uses: iwamot/workflows/.github/workflows/dependency-review.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/dependency-review.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0

--- a/.github/workflows/oide.yml
+++ b/.github/workflows/oide.yml
@@ -13,7 +13,7 @@ jobs:
   pull:
     permissions:
       contents: read
-    uses: iwamot/workflows/.github/workflows/oide.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/oide.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0
     with:
       # renovate: datasource=github-tags depName=iwamot/repo-template
       TEMPLATE_VERSION: v1.5.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,12 @@ permissions: {}
 
 jobs:
   release:
-    uses: iwamot/workflows/.github/workflows/release-ecr-public.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/release-ecr-public.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0
     permissions:
       contents: write  # to draft and publish the GitHub Release
-      id-token: write  # to mint OIDC token for AWS role assumption and cosign signing
+      id-token: write  # to mint OIDC tokens for AWS role assumption, cosign, and attest
+      attestations: write  # to write the provenance attestation
+      artifact-metadata: write  # to record artifact metadata for the attestation
     with:
       registry_image: public.ecr.aws/k7d3h0b5/iwamot/marp-agent-mcp
     secrets:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,7 +21,7 @@ jobs:
   renovate:
     permissions:
       contents: read
-    uses: iwamot/workflows/.github/workflows/renovate.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/renovate.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0
     with:
       log-level: ${{ inputs.log-level || 'info' }}
     secrets:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,4 +14,4 @@ jobs:
     permissions:
       contents: read
       id-token: write  # for Codecov OIDC upload
-    uses: iwamot/workflows/.github/workflows/validate-with-coverage.yml@7e1e1b73633f829ea0ac1ca934aa4d085561d61a # v7.1.0
+    uses: iwamot/workflows/.github/workflows/validate-with-coverage.yml@1d30033350f397a683dfdf04708d1a510969e9ed # v8.0.0


### PR DESCRIPTION
## Summary
- `iwamot/workflows` の参照を v7.1.0 から v8.0.0 にバンプ
- `release-ecr-public.yml` 経路では merge-and-sign job の中で `actions/attest@v4` が走るようになったため、caller の release job に `attestations: write` と `artifact-metadata: write` を付与し、`id-token: write` のコメントを「AWS role assumption + cosign + attest 用」に更新
- attest と無関係な他 7 つの reusable workflow 参照（dependabot-auto-merge / renovate / dco / oide / dependency-review / auto-label / validate）も、repo を単一バージョンに揃えるため同時に SHA bump（v8.0.0 で機能変更は無い）

タグを切った後、image の利用者は以下で SLSA build provenance を verify 可能：

```
gh attestation verify oci://public.ecr.aws/k7d3h0b5/iwamot/marp-agent-mcp:<tag> --owner iwamot
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)