### PR TITLE
chore: 先祖返りした .github/dco.yml を削除

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,2 +1,0 @@
-allowRemediationCommits:
-  individual: true


### PR DESCRIPTION
## Summary
- 先祖返りした `.github/dco.yml` (DCO App config) を削除

## Why
iwamot/repo-template から `.github/dco.yml` と Oidefile の対応エントリは #68 で削除済みだったが、v1.6.0 タグの作成が今日まで未対応だった。直前の workflows v8.0.0 への bump (#292) を merge したタイミングで Oide workflow が `TEMPLATE_VERSION: v1.5.0` で実行されてしまい、削除済みのエントリが再配布されてファイルが復活した。

Oidefile のエントリ削除と TEMPLATE_VERSION の v1.6.0 への bump は Renovate が既に処理済みなので、本 PR ではファイル本体の削除だけ実施する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)