### PR TITLE
chore: move Oidefile under .github/

### DIFF
--- a/.github/Oidefile
+++ b/.github/Oidefile
@@ -1,4 +1,4 @@
+.github/Oidefile
 .github/release.yml
 CONTRIBUTING.md
-Oidefile
 SECURITY.md


### PR DESCRIPTION
Move the manifest to `.github/Oidefile`, update its self entry to match, and sort the entries.