### PR TITLE
chore: route mise npm backend through aube, drop redundant install_before

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,18 +1,21 @@
-min_version = "2026.4.17"
+min_version = "2026.6.3"
 
 [settings]
-install_before = "1d"
+npm.package_manager = "aube"
+
+[env]
+AUBE_ALLOWED_UNPOPULAR_PACKAGES = "pnpm-override-prune"
 
 [tools]
 biome = "2.4.13"
 bun = "1.3.14"
 node = "24.16.0"
-"npm:@endevco/aube" = { version = "1.18.1", npm_args = "--ignore-scripts=false" }
+"aqua:jdx/aube" = "1.18.1"
 "npm:@marp-team/marp-cli" = "4.4.0"
 
 [tools."npm:pnpm-override-prune"]
 version = "0.0.7"
-install_before = "0d"
+minimum_release_age = "0d"
 
 [task_config]
 includes = [


### PR DESCRIPTION
mise v2026.6.2 defaults minimum_release_age to 24h, so drop the now-redundant install_before (raising min_version to 2026.6.3) and rename the per-tool install_before = "0d" override to minimum_release_age = "0d".

Pin aube through the aqua backend instead of the npm package and set npm.package_manager = aube so mise installs the npm: tools via aube with provenance trust checking.