### PR TITLE
fix(deps): install aube from GitHub releases instead of the dead npm package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,15 @@ FROM public.ecr.aws/docker/library/node:24.16.0-trixie-slim@sha256:45fbb3ca3b6c7
 
 WORKDIR /app
 
-# Install aube and bun
-# renovate: datasource=npm depName=npm:@endevco/aube packageName=@endevco/aube
-ARG AUBE_VERSION=1.18.1
+# Install aube (distributed via GitHub releases, not npm) and bun
+# renovate: datasource=github-tags depName=aqua:jdx/aube packageName=jdx/aube extractVersion=^v?(?<version>.+)
+ARG AUBE_VERSION=1.19.0
+ADD https://github.com/jdx/aube/releases/download/v${AUBE_VERSION}/aube-v${AUBE_VERSION}-x86_64-unknown-linux-gnu.tar.gz /tmp/aube.tgz
+RUN tar -xzf /tmp/aube.tgz -C /usr/local/bin aube && rm /tmp/aube.tgz
+
 # renovate: datasource=github-releases depName=bun packageName=oven-sh/bun versioning=semver-coerced extractVersion=^bun-v(?<version>\S+)
 ARG BUN_VERSION=1.3.14
-RUN npm install -g @endevco/aube@${AUBE_VERSION} bun@${BUN_VERSION}
+RUN npm install -g bun@${BUN_VERSION}
 
 # Install dependencies
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./


### PR DESCRIPTION
## Background

The aube project moved from the `endevco` namespace to `jdx` (release v1.18.2, "Project moves to jdx"). As a result:

- npm publishing under `@endevco/aube` stopped at `1.18.1`.
- `@jdx/aube` was announced as the new npm coordinate but has never actually been published (404 on the registry).
- aube ≥ 1.18.2 is distributed only via GitHub releases (the source `aqua` uses) and Homebrew (`jdx/tap/aube`).

Because of this, the Dockerfile's `npm install -g @endevco/aube@${AUBE_VERSION}` was pinned to `1.18.1` with no upgrade path, while `mise.toml` tracks `aqua:jdx/aube` and has already moved on (`1.19.0`). The two install sources had diverged, and Renovate could no longer bump the Dockerfile copy.

## Change

- Install aube from the `jdx/aube` GitHub release tarball via `ADD` + `tar` (no `curl`/`wget` needed in `node:*-trixie-slim`, which ships `tar`/`gzip`). `bun` keeps using `npm install -g`.
- Set `AUBE_VERSION=1.19.0` to match `mise.toml`.
- Align the Renovate annotation with mise's detected dependency (`datasource=github-tags`, `depName=aqua:jdx/aube`, `packageName=jdx/aube`, `extractVersion=^v?(?<version>.+)`). A local `renovate --dry-run=extract` confirms the Dockerfile and `mise.toml` now resolve to an identical dependency, so both are bumped together in a single PR.

The build-time install mechanism changes only; the runtime image is unaffected.