### PR TITLE
chore: exclude nanoid@3.3.14 from aube trust-downgrade policy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,6 @@
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - pnpm-override-prune
+trustPolicyExclude:
+  - nanoid@3.3.14
 overrides: {}


### PR DESCRIPTION
## What

Add `nanoid@3.3.14` to `trustPolicyExclude` in `pnpm-workspace.yaml`.

## Why

aube 1.22.0 enforces `trustPolicy=no-downgrade` by default: it rejects a version whose trust evidence is weaker than an earlier-published version of the same package. `@marp-team/marp-cli@4.4.0` (a mise tool) pulls in `nanoid@3.3.14` transitively. nanoid's v3 CJS LTS line predates trusted publishing, so its manual backport releases carry no attestations while the v5 line does. aube reads this as a trust downgrade (`ERR_AUBE_TRUST_DOWNGRADE`) and fails `mise install`, which breaks CI across the whole repo — not just on any single dependency PR.

`nanoid@3.3.14` is published by nanoid's sole maintainer from the official `ai/nanoid` repo (verified `_npmUser` / maintainers / gitHead), and no advisory ties it to a supply-chain incident, so the downgrade signal is a false positive.

## Scope

The exclusion targets the exact version (not a semver range), so any future nanoid release re-triggers the policy and gets reviewed again. `no-downgrade` stays in effect for every other package.