### PR TITLE
chore: move aube trust-downgrade exclude for nanoid to mise env

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,7 @@ npm.package_manager = "aube"
 
 [env]
 AUBE_ALLOWED_UNPOPULAR_PACKAGES = "pnpm-override-prune"
+AUBE_TRUST_POLICY_EXCLUDE = "nanoid@3.3.14"
 
 [tools]
 biome = "2.4.13"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,4 @@
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - pnpm-override-prune
-trustPolicyExclude:
-  - nanoid@3.3.14
 overrides: {}


### PR DESCRIPTION
## What

Set `AUBE_TRUST_POLICY_EXCLUDE = "nanoid@3.3.14"` in `mise.toml` `[env]`, and revert the now-redundant `trustPolicyExclude` entry in `pnpm-workspace.yaml` added in #346.

## Why

#346 added the exclude to `pnpm-workspace.yaml`, but CI kept failing on a fresh (uncached) run. mise installs `@marp-team/marp-cli` as an npm tool by invoking aube in an isolated `installs/` directory, so aube never reads the project's `pnpm-workspace.yaml` in that step. The `no-downgrade` gate on `nanoid@3.3.14` (a transitive dep of marp-cli) therefore still failed `mise install`.

`AUBE_TRUST_POLICY_EXCLUDE` is a global aube setting, so placing it in `mise.toml [env]` covers both the marp-cli tool install and the project's own `aube install` — making the `pnpm-workspace.yaml` entry redundant. This mirrors the existing `AUBE_ALLOWED_UNPOPULAR_PACKAGES` env in the same file.

## Verification

Reproduced locally by uninstalling the marp-cli mise tool and re-running `mise install` with the new env: marp-cli resolves and installs with no trust-downgrade error (the same step that fails in CI without it).