### PR TITLE
fix: select the aube tarball by TARGETARCH in the Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,15 @@ FROM public.ecr.aws/docker/library/node:24.18.0-trixie-slim@sha256:ae91dcc111a68
 
 WORKDIR /app
 
-# Install aube (distributed via GitHub releases, not npm) and bun
+# Install aube (distributed via GitHub releases, not npm) and bun.
+# aube tarballs are named per architecture and the slim image has no
+# curl/wget, so ADD both and extract the one matching TARGETARCH.
 # renovate: datasource=github-tags depName=aqua:jdx/aube packageName=jdx/aube extractVersion=^v?(?<version>.+)
 ARG AUBE_VERSION=1.29.1
-ADD https://github.com/jdx/aube/releases/download/v${AUBE_VERSION}/aube-v${AUBE_VERSION}-x86_64-unknown-linux-gnu.tar.gz /tmp/aube.tgz
-RUN tar -xzf /tmp/aube.tgz -C /usr/local/bin aube && rm /tmp/aube.tgz
+ARG TARGETARCH
+ADD https://github.com/jdx/aube/releases/download/v${AUBE_VERSION}/aube-v${AUBE_VERSION}-x86_64-unknown-linux-gnu.tar.gz /tmp/aube-amd64.tgz
+ADD https://github.com/jdx/aube/releases/download/v${AUBE_VERSION}/aube-v${AUBE_VERSION}-aarch64-unknown-linux-gnu.tar.gz /tmp/aube-arm64.tgz
+RUN tar -xzf "/tmp/aube-${TARGETARCH}.tgz" -C /usr/local/bin aube && rm /tmp/aube-*.tgz
 
 # renovate: datasource=github-releases depName=bun packageName=oven-sh/bun versioning=semver-coerced extractVersion=^bun-v(?<version>\S+)
 ARG BUN_VERSION=1.3.14


### PR DESCRIPTION
## Summary

The aube download URL in the Dockerfile was hardcoded to the x86_64 tarball, so the linux/arm64 image build failed with `aube: Exec format error` at `RUN aube install`. This surfaced in the v0.1.9 release run ([failed job](https://github.com/iwamot/marp-agent-mcp/actions/runs/29738293154/job/88338844549)) because arm64 images are only built by the release workflow, and the GitHub-releases install path was introduced after v0.1.8 (#335).

## Fix

ADD both architecture tarballs and extract the one matching `TARGETARCH` in the RUN step.

Alternatives considered:
- Branching the download inside RUN: the slim base image has no curl/wget.
- Per-arch alias stages selected via `FROM app-builder-${TARGETARCH}`: hadolint cannot resolve a variable stage reference and flags it as DL3006 (hadolint/hadolint#161).
- Installing via mise (`COPY --from=ghcr.io/jdx/mise` + mise.toml/mise.lock): works, but requires apt-installing ca-certificates first, since mise validates TLS against the system CA store that the slim image does not ship.

BuildKit caches ADD by URL, so the unused tarball costs one extra cached download (~28 MB) per aube version.

## Verification

- `docker build --target app-builder` succeeds locally for amd64 (aube extract → `aube install` → `aube run build`)
- The aarch64 tarball was downloaded and confirmed to contain an ELF ARM aarch64 `aube` binary at the expected path
- hadolint passes with no findings and no ignores

🤖 Generated with [Claude Code](https://claude.com/claude-code)