### PR TITLE
fix(deps): move pnpm overrides to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,9 +52,5 @@
   },
   "bin": {
     "marp-agent-mcp": "dist/index.js"
-  },
-  "overrides": {
-    "@hono/node-server": ">=2.0.10",
-    "shell-quote": ">=1.9.0"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,6 @@
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - pnpm-override-prune
-overrides: {}
+overrides:
+  '@hono/node-server': '>=2.0.10'
+  shell-quote: '>=1.9.0'


### PR DESCRIPTION
## Summary

The overrides for `@hono/node-server` and `shell-quote` (added in #382) live in `package.json` as a top-level `"overrides"` field. aube reads that field, but pnpm does not — pnpm reads overrides from `pnpm-workspace.yaml`. Renovate regenerates `pnpm-lock.yaml` with plain pnpm, so its lockfile updates silently drop the overrides. This reintroduced the vulnerable `shell-quote@1.8.4` (CWE-407, high severity) and broke both the dependency-review and frozen-lockfile checks on #384.

This PR moves the overrides to the `overrides` field in `pnpm-workspace.yaml`, where both aube and pnpm apply them. `pnpm-lock.yaml` is unchanged because it already reflects these overrides.

After merging, rebasing #384 should make its lockfile keep the overrides and pass CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)