### PR TITLE
chore: restore the node musl checksums in mise.lock

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -185,6 +185,7 @@ checksum = "sha256:df224555a083b918e46260cc969838501b9f9a87140c1195e5b9597b56d5d
 url = "https://nodejs.org/dist/v24.18.1/node-v24.18.1-linux-arm64.tar.gz"
 
 [tools.node."platforms.linux-arm64-musl"]
+checksum = "sha256:ae1b6457edb875fd98130b37c853e51a53ac0cc40850ecccd490b61c5a3558fa"
 url = "https://unofficial-builds.nodejs.org/download/release/v24.18.1/node-v24.18.1-linux-arm64-musl.tar.gz"
 
 [tools.node."platforms.linux-x64"]
@@ -196,9 +197,11 @@ checksum = "sha256:9f5eb6ac21845a66c493c91a253b1da32fd684e89e9b7202d4936982336be
 url = "https://nodejs.org/dist/v24.18.1/node-v24.18.1-linux-x64.tar.gz"
 
 [tools.node."platforms.linux-x64-musl"]
+checksum = "sha256:696979caef92505ad7566a3674ca9a93d8558e282f34e7899181c0321821ae5f"
 url = "https://unofficial-builds.nodejs.org/download/release/v24.18.1/node-v24.18.1-linux-x64-musl.tar.gz"
 
 [tools.node."platforms.linux-x64-musl-baseline"]
+checksum = "sha256:696979caef92505ad7566a3674ca9a93d8558e282f34e7899181c0321821ae5f"
 url = "https://unofficial-builds.nodejs.org/download/release/v24.18.1/node-v24.18.1-linux-x64-musl.tar.gz"
 
 [tools.node."platforms.macos-arm64"]


### PR DESCRIPTION
The musl platform entries in `mise.lock` carry a url and no checksum, so `mise install` fills them in on every CI run and the `git diff --exit-code` that ends `validate.sh` fails. Every pull request opened since has failed there, this one's parent commit included.

`mise lock node` writes the checksums the three entries were missing (`linux-arm64-musl`, `linux-x64-musl`, `linux-x64-musl-baseline`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
