### PR TITLE
fix(deps): override js-yaml to >=5.2.1 to resolve CVE-2026-59870

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-yaml: '>=5.2.1'
+
 importers:
 
   .:
@@ -711,8 +714,8 @@ packages:
   jose@6.2.4:
     resolution: {integrity: sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@5.2.3:
+    resolution: {integrity: sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==}
     hasBin: true
 
   json-schema-traverse@1.0.0:
@@ -1212,7 +1215,7 @@ snapshots:
     dependencies:
       '@csstools/postcss-is-pseudo-class': 5.0.3(postcss@8.5.23)
       cssesc: 3.0.0
-      js-yaml: 4.3.0
+      js-yaml: 5.2.3
       lodash.kebabcase: 4.1.1
       markdown-it: 14.3.0
       markdown-it-front-matter: 0.2.4
@@ -1703,7 +1706,7 @@ snapshots:
 
   jose@6.2.4: {}
 
-  js-yaml@4.3.0:
+  js-yaml@5.2.3:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - pnpm-override-prune
-overrides: {}
+overrides:
+  js-yaml: '>=5.2.1'


### PR DESCRIPTION
`@marp-team/marpit` depends on `js-yaml@^4.3.0`, which resolved to 4.3.0 — a version affected by quadratic CPU consumption in `!!omap` resolution. `aube audit` fails on it, blocking every dependency PR.

The floor is set to `>=5.2.1` rather than `>=4.3.1` because 5.2.0 carries the same regression, fixed in 5.2.1. A bounded range (`>=4.3.1 <5`) was avoided so that `pnpm-override-prune` can drop the entry once marpit's own range catches up.

Marpit still declares `^4.3.0`, so this crosses a major. Front-matter directive parsing (`theme`, `paginate`, `header`, slide splitting) was verified against the new resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)