### PR TITLE
chore: run Renovate every six hours

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 */6 * * *'
   workflow_dispatch:
     inputs:
       log-level:


### PR DESCRIPTION
Most hourly runs found nothing to do. Updates are held for a day by the release-age gate before they can be proposed at all, and merging one triggers the next run through the push event, so the schedule only decides how promptly a day-old update gets noticed — not how much lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)