### PR TITLE
chore: run Dependabot auto-merge only on main pull requests

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,7 @@
 name: Dependabot auto-merge
-on: pull_request
+on:
+  pull_request:
+    branches: [ "main" ]
 
 permissions: {}
 


### PR DESCRIPTION
Match the branch filter used by the other pull request workflows. The job is skipped on pull requests that do not target `main`, so this only stops the run from being created.