### PR TITLE
chore: drop the dead nanoid trust-policy exclude

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,6 @@ npm.package_manager = "aube"
 
 [env]
 AUBE_ALLOWED_UNPOPULAR_PACKAGES = "pnpm-override-prune"
-AUBE_TRUST_POLICY_EXCLUDE = "nanoid@3.3.14"
 
 [tools]
 biome = "2.4.13"


### PR DESCRIPTION
The entry pinned the exact version `nanoid@3.3.14`, which no longer appears in any resolved tree: the repository lockfile carries 3.3.17 and `npm:@marp-team/marp-cli` resolves 3.3.18. Both install with the exclusion removed, so the aube `no-downgrade` policy passes on its own for the v3 line and the entry protects nothing.