### PR TITLE
chore: migrate the Biome linter preset field

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "suspicious": {
         "noExplicitAny": "error"
       }


### PR DESCRIPTION
Biome 2.5 deprecates `linter.rules.recommended` in favour of `linter.rules.preset` and removes it in the next major, so every `biome check` run reports the config as deprecated. The rewrite is what `biome migrate` produces, and the set of enabled rules is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)