### PR TITLE
chore: drop aube settings with no referent

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,9 +4,6 @@ min_version = "2026.7.5"
 lockfile = true
 npm.package_manager = "aube"
 
-[env]
-AUBE_ALLOWED_UNPOPULAR_PACKAGES = "pnpm-override-prune"
-
 [tools]
 biome = "2.5.8"
 bun = "1.3.14"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,2 @@
-minimumReleaseAge: 1440
-minimumReleaseAgeExclude:
-  - pnpm-override-prune
 overrides:
   js-yaml: '>=5.2.1'


### PR DESCRIPTION
`minimumReleaseAge: 1440` restates aube's own default. The `minimumReleaseAgeExclude` entry and the `AUBE_ALLOWED_UNPOPULAR_PACKAGES` env both name `pnpm-override-prune`, which is installed as a mise tool and is not a project dependency, so the workspace exclude has nothing to match.

The tool installs with the env unset and aube's trust-policy cache cleared, and `aube install --frozen-lockfile` is unaffected by dropping the release-age line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)