### PR TITLE
chore: pin the lockfile format to pnpm

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
+# aube writes its own lockfile format when none is present, and Renovate's npm
+# manager does not read it. This keeps a regenerated lockfile on the format
+# that both sides can update.
+defaultLockfileFormat: pnpm
+
 overrides:
   js-yaml: '>=5.2.1'


### PR DESCRIPTION
aube writes its own lockfile format when no lockfile is present, and Renovate's npm manager reads `package-lock.json`, `npm-shrinkwrap.json`, `pnpm-lock.yaml` and `yarn.lock` — not that one. Declaring the format keeps a regenerated lockfile on the one both sides can update.

Nothing is regenerated here: `pnpm-lock.yaml` is unchanged and the setting only decides which format gets created when no lockfile exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)