### PR TITLE
fix: restore the jose pin the dedupe swept up

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,8 +684,8 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  jose@6.2.9:
-    resolution: {integrity: sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==}
+  jose@6.2.4:
+    resolution: {integrity: sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==}
 
   js-yaml@5.3.0:
     resolution: {integrity: sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==}
@@ -1194,7 +1194,7 @@ snapshots:
       express: 5.2.1
       express-rate-limit: 8.6.2(express@5.2.1)
       hono: 4.13.2
-      jose: 6.2.9
+      jose: 6.2.4
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
@@ -1646,7 +1646,7 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  jose@6.2.9: {}
+  jose@6.2.4: {}
 
   js-yaml@5.3.0:
     dependencies:


### PR DESCRIPTION
The dedupe that moved nanoid to 3.3.18 re-resolved unrelated transitive pins as well, and took `jose` 6.2.9 six hours after its release. pnpm rejects a lockfile while any entry is younger than `minimumReleaseAge`, so Renovate could not refresh it and opened manifest-only branches that CI then failed on — #433 is one.

`jose` returns to 6.2.4, the version the lockfile held before that dedupe. `@modelcontextprotocol/sdk` is its only dependent, and its range is unchanged, so the four lines here are the whole revert. pnpm accepts the lockfile again and regenerating it from this state produces no further change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)