### PR TITLE
chore: raise the mise floor to 2026.8.9

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
-min_version = "2026.8.6"
+min_version = "2026.8.9"
 
 [settings]
 lockfile = true


### PR DESCRIPTION
mise 2026.8.9 changed the aqua backend to prefer glibc release assets over musl on glibc Linux (jdx/mise#12093). Renovate regenerates mise.lock with current mise, so locks now record the glibc asset URLs, while CI pinned to an older mise still resolves install paths from the musl assets and fails with a missing binary.

This repo's lock records no gnu/musl sibling assets, so only the floor moves; raising it keeps the mise that writes the lock and the mise that reads it on the same policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)