### PR TITLE
chore: move the oide caller to the SOURCES input

### DIFF
--- a/.github/workflows/oide.yml
+++ b/.github/workflows/oide.yml
@@ -15,8 +15,9 @@ jobs:
       contents: read
     uses: iwamot/workflows/.github/workflows/oide.yml@3a60350ff82e769fc95271d672a481d135d0c059 # v8.8.4
     with:
-      # renovate: datasource=github-tags depName=iwamot/repo-template
-      TEMPLATE_VERSION: v1.10.0
+      SOURCES: |
+        # renovate: datasource=github-tags depName=iwamot/repo-template
+        iwamot/repo-template@v1.10.0
     secrets:
       OIDE_APP_CLIENT_ID: ${{ secrets.OIDE_APP_CLIENT_ID }}
       OIDE_APP_PRIVATE_KEY: ${{ secrets.OIDE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
`iwamot/workflows`' `oide.yml` marks `TEMPLATE_VERSION` as deprecated in favour of `SOURCES`, which takes the same `iwamot/repo-template@<tag>` pin as one line of a multi-line input, with the Renovate annotation above it. This switches the caller over; the pinned tag and everything else stay as they are.