### PR TITLE
chore: make codecov statuses informational

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Add `.codecov.yml` so the project and patch statuses from Codecov are informational. Coverage stays visible on each PR for looking back at the trend, and a drop in coverage no longer marks the PR as failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
